### PR TITLE
Add jQuery throttle / debounce plugin 1.1

### DIFF
--- a/ajax/libs/jquery-throttle-debounce/1.1/jquery.ba-throttle-debounce.min.js
+++ b/ajax/libs/jquery-throttle-debounce/1.1/jquery.ba-throttle-debounce.min.js
@@ -1,0 +1,9 @@
+/*
+ * jQuery throttle / debounce - v1.1 - 3/7/2010
+ * http://benalman.com/projects/jquery-throttle-debounce-plugin/
+ * 
+ * Copyright (c) 2010 "Cowboy" Ben Alman
+ * Dual licensed under the MIT and GPL licenses.
+ * http://benalman.com/about/license/
+ */
+(function(b,c){var $=b.jQuery||b.Cowboy||(b.Cowboy={}),a;$.throttle=a=function(e,f,j,i){var h,d=0;if(typeof f!=="boolean"){i=j;j=f;f=c}function g(){var o=this,m=+new Date()-d,n=arguments;function l(){d=+new Date();j.apply(o,n)}function k(){h=c}if(i&&!h){l()}h&&clearTimeout(h);if(i===c&&m>e){l()}else{if(f!==true){h=setTimeout(i?k:l,i===c?e-m:e)}}}if($.guid){g.guid=j.guid=j.guid||$.guid++}return g};$.debounce=function(d,e,f){return f===c?a(d,e,false):a(d,f,e!==false)}})(this);

--- a/ajax/libs/jquery-throttle-debounce/package.json
+++ b/ajax/libs/jquery-throttle-debounce/package.json
@@ -1,0 +1,25 @@
+{
+    "name": "jQuery throttle / debounce",
+    "filename": "jquery.ba-throttle-debounce.min.js",
+    "version": "1.1",
+    "description": "jQuery throttle / debounce allows you to rate-limit your functions in multiple useful ways.",
+    "homepage": "https://github.com/cowboy/jquery-throttle-debounce",
+    "keywords": [
+       "jquery",
+       "throttle",
+       "debounce",
+       "ratelimit"
+   ],
+   "maintainers": [
+       {
+           "name": "Ben Alman",
+           "web": "http://benalman.com"
+       } 
+   ],
+   "repositories": [
+       {
+           "type": "git",
+           "url": "https://github.com/cowboy/jquery-throttle-debounce.git" 
+       } 
+   ]
+}


### PR DESCRIPTION
jQuery throttle / debounce allows you to rate-limit your functions in
multiple useful ways. Passing a delay and callback to $.throttle
returns a new function that will execute no more than once every
delay milliseconds. Passing a delay and callback to $.debounce
returns a new function that will execute only once, coalescing
multiple sequential calls into a single execution at either the very
beginning or end.

I've opened a discussion today, you may want to wait it become more popular before pulling if you are unsure of the usefulness:
http://cdnjs.uservoice.com/forums/98277-general/suggestions/2450401-ben-alman-s-jquery-throttle-debounce

License: MIT / GPL
Homepage: http://benalman.com/projects/jquery-throttle-debounce-plugin/
