### PR TITLE
Adding jQuery Cookie

### DIFF
--- a/ajax/libs/jquery-cookie/1.0/jquery.cookie.min.js
+++ b/ajax/libs/jquery-cookie/1.0/jquery.cookie.min.js
@@ -1,0 +1,11 @@
+/**
+ * jQuery Cookie plugin
+ *
+ * Copyright (c) 2010 Klaus Hartl (stilbuero.de)
+ * Dual licensed under the MIT and GPL licenses:
+ * http://www.opensource.org/licenses/mit-license.php
+ * http://www.gnu.org/licenses/gpl.html
+ *
+ */
+jQuery.cookie=function(e,b,a){if(1<arguments.length&&"[object Object]"!==""+b){a=jQuery.extend({},a);if(null===b||void 0===b)a.expires=-1;if("number"===typeof a.expires){var d=a.expires,c=a.expires=new Date;c.setDate(c.getDate()+d)}b=""+b;return document.cookie=[encodeURIComponent(e),"=",a.raw?b:encodeURIComponent(b),a.expires?"; expires="+a.expires.toUTCString():"",a.path?"; path="+a.path:"",a.domain?"; domain="+a.domain:"",a.secure?"; secure":""].join("")}a=b||{};c=a.raw?function(a){return a}:decodeURIComponent;
+return(d=RegExp("(?:^|; )"+encodeURIComponent(e)+"=([^;]*)").exec(document.cookie))?c(d[1]):null};

--- a/ajax/libs/jquery-cookie/package.json
+++ b/ajax/libs/jquery-cookie/package.json
@@ -1,0 +1,24 @@
+{
+    "name": "jQuery Cookie",
+    "filename": "jquery.cookie.min.js",
+    "version": "1.0",
+    "description": "A simple, lightweight jQuery plugin for reading, writing and deleting cookies.",
+    "homepage": "https://github.com/carhartl/jquery-cookie",
+    "keywords": [
+       "jQuery",
+       "cookies"
+   ],
+   "maintainers": [
+       {
+           "name": "Klaus Hartl"
+       } 
+   ],
+   "repositories": [
+       {
+           "type": "git",
+           "url": "https://github.com/carhartl/jquery-cookie" 
+       } 
+   ]
+
+}
+


### PR DESCRIPTION
jQuery Cookie is a really useful, light wrapper around the terrible default cookie API. It'd be nice to have a readily available version on a CDN.

https://github.com/carhartl/jquery-cookie
