### PR TITLE
Fix jquery-history repository

### DIFF
--- a/ajax/libs/jquery-history/package.json
+++ b/ajax/libs/jquery-history/package.json
@@ -16,8 +16,8 @@
    ],
    "repositories": [
        { 
-           "type": "plain file",
-           "url": "https://raw.github.com/tkyk/jquery-history-plugin/master/jquery.history.js" 
+           "type": "git",
+           "url": "https://github.com/tkyk/jquery-history-plugin.git" 
        } 
    ]
 


### PR DESCRIPTION
BTW the plugin is unmaintained [1] so i'm wondering since it's a very fresh addition if it's not the case to remove it instead. We are already shipping history.js for the same use case. Adding @bkerensa.

[1] https://github.com/tkyk/jquery-history-plugin
