### PR TITLE
Fix History.js url

### DIFF
--- a/ajax/libs/history.js/1.7.1/native.history.js
+++ b/ajax/libs/history.js/1.7.1/native.history.js
@@ -1,0 +1,1 @@
+bundled/html4+html5/native.history.js


### PR DESCRIPTION
I think the less ugly way to fix it is to add a symlink of the
file referenced in the name.

Fix #195
