### PR TITLE
Ignore .htaccess files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 *~
 .DS_STORE
+.htaccess


### PR DESCRIPTION
For internal coding reasons, I am trying to run this repository on apache server locally, and for permissions reasons, I need .htaccess files, but I--of course--don't want them official in the repo.  So I have added the directive for git to ignore them.
