### PR TITLE
Vert.x 1.3.0

### DIFF
--- a/ajax/libs/vertx/1.3.0/vertxbus.js
+++ b/ajax/libs/vertx/1.3.0/vertxbus.js
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2011-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var vertx = vertx || {};
+
+!function(factory) {
+  if (typeof define === "function" && define.amd) {
+    // Expose as an AMD module with SockJS dependency.
+    // "vertxbus" and "sockjs" names are used because
+    // AMD module names are derived from file names.
+    define("vertxbus", ["sockjs"], factory);
+  } else {
+    // No AMD-compliant loader
+    factory(SockJS);
+  }
+}(function(SockJS) {
+
+  vertx.EventBus = function(url, options) {
+  
+    var that = this;
+    var sockJSConn = new SockJS(url, options);
+    var handlerMap = {};
+    var replyHandlers = {};
+    var state = vertx.EventBus.CONNECTING;
+  
+    that.onopen = null;
+    that.onclose = null;
+  
+    that.send = function(address, message, replyHandler) {
+      sendOrPub("send", address, message, replyHandler)
+    }
+  
+    that.publish = function(address, message, replyHandler) {
+      sendOrPub("publish", address, message, replyHandler)
+    }
+  
+    that.registerHandler = function(address, handler) {
+      checkSpecified("address", 'string', address);
+      checkSpecified("handler", 'function', handler);
+      checkOpen();
+      var handlers = handlerMap[address];
+      if (!handlers) {
+        handlers = [handler];
+        handlerMap[address] = handlers;
+        // First handler for this address so we should register the connection
+        var msg = { type : "register",
+                    address: address };
+        sockJSConn.send(JSON.stringify(msg));
+      } else {
+        handlers[handlers.length] = handler;
+      }
+    }
+  
+    that.unregisterHandler = function(address, handler) {
+      checkSpecified("address", 'string', address);
+      checkSpecified("handler", 'function', handler);
+      checkOpen();
+      var handlers = handlerMap[address];
+      if (handlers) {
+        var idx = handlers.indexOf(handler);
+        if (idx != -1) handlers.splice(idx, 1);
+        if (handlers.length == 0) {
+          // No more local handlers so we should unregister the connection
+  
+          var msg = { type : "unregister",
+                      address: address};
+          sockJSConn.send(JSON.stringify(msg));
+          delete handlerMap[address];
+        }
+      }
+    }
+  
+    that.close = function() {
+      checkOpen();
+      state = vertx.EventBus.CLOSING;
+      sockJSConn.close();
+    }
+  
+    that.readyState = function() {
+      return state;
+    }
+  
+    sockJSConn.onopen = function() {
+      state = vertx.EventBus.OPEN;
+      if (that.onopen) {
+        that.onopen();
+      }
+    };
+  
+    sockJSConn.onclose = function() {
+      state = vertx.EventBus.CLOSED;
+      if (that.onclose) {
+        that.onclose();
+      }
+    };
+  
+    sockJSConn.onmessage = function(e) {
+      var msg = e.data;
+      var json = JSON.parse(msg);
+      var body = json.body;
+      var replyAddress = json.replyAddress;
+      var address = json.address;
+      var replyHandler;
+      if (replyAddress) {
+        replyHandler = function(reply, replyHandler) {
+          // Send back reply
+          that.send(replyAddress, reply, replyHandler);
+        };
+      }
+      var handlers = handlerMap[address];
+      if (handlers) {
+        // We make a copy since the handler might get unregistered from within the
+        // handler itself, which would screw up our iteration
+        var copy = handlers.slice(0);
+        for (var i  = 0; i < copy.length; i++) {
+          copy[i](body, replyHandler);
+        }
+      } else {
+        // Might be a reply message
+        var handler = replyHandlers[address];
+        if (handler) {
+          delete replyHandlers[replyAddress];
+          handler(body, replyHandler);
+        }
+      }
+    }
+  
+    function sendOrPub(sendOrPub, address, message, replyHandler) {
+      checkSpecified("address", 'string', address);
+      checkSpecified("message", 'object', message);
+      checkSpecified("replyHandler", 'function', replyHandler, true);
+      checkOpen();
+      var envelope = { type : sendOrPub,
+                       address: address,
+                       body: message };
+      if (replyHandler) {
+        var replyAddress = makeUUID();
+        envelope.replyAddress = replyAddress;
+        replyHandlers[replyAddress] = replyHandler;
+      }
+      var str = JSON.stringify(envelope);
+      sockJSConn.send(str);
+    }
+  
+    function checkOpen() {
+      if (state != vertx.EventBus.OPEN) {
+        throw new Error('INVALID_STATE_ERR');
+      }
+    }
+  
+    function checkSpecified(paramName, paramType, param, optional) {
+      if (!optional && !param) {
+        throw new Error("Parameter " + paramName + " must be specified");
+      }
+      if (param && typeof param != paramType) {
+        throw new Error("Parameter " + paramName + " must be of type " + paramType);
+      }
+    }
+  
+    function isFunction(obj) {
+      return !!(obj && obj.constructor && obj.call && obj.apply);
+    }
+  
+    function makeUUID(){return"xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx"
+        .replace(/[xy]/g,function(a,b){return b=Math.random()*16,(a=="y"?b&3|8:b|0).toString(16)})}
+  
+  }
+  
+  vertx.EventBus.CONNECTING = 0;
+  vertx.EventBus.OPEN = 1;
+  vertx.EventBus.CLOSING = 2;
+  vertx.EventBus.CLOSED = 3;
+
+  return vertx.EventBus;
+
+});

--- a/ajax/libs/vertx/1.3.0/vertxbus.min.js
+++ b/ajax/libs/vertx/1.3.0/vertxbus.min.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2011-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */var vertx=vertx||{};!function(e){typeof define=="function"&&define.amd?define("vertxbus",["sockjs"],e):e(SockJS)}(function(e){return vertx.EventBus=function(t,n){function a(e,t,n,r){l("address","string",t),l("message","object",n),l("replyHandler","function",r,!0),f();var s={type:e,address:t,body:n};if(r){var u=h();s.replyAddress=u,o[u]=r}var a=JSON.stringify(s);i.send(a)}function f(){if(u!=vertx.EventBus.OPEN)throw new Error("INVALID_STATE_ERR")}function l(e,t,n,r){if(!r&&!n)throw new Error("Parameter "+e+" must be specified");if(n&&typeof n!=t)throw new Error("Parameter "+e+" must be of type "+t)}function c(e){return!!(e&&e.constructor&&e.call&&e.apply)}function h(){return"xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g,function(e,t){return t=Math.random()*16,(e=="y"?t&3|8:t|0).toString(16)})}var r=this,i=new e(t,n),s={},o={},u=vertx.EventBus.CONNECTING;r.onopen=null,r.onclose=null,r.send=function(e,t,n){a("send",e,t,n)},r.publish=function(e,t,n){a("publish",e,t,n)},r.registerHandler=function(e,t){l("address","string",e),l("handler","function",t),f();var n=s[e];if(!n){n=[t],s[e]=n;var r={type:"register",address:e};i.send(JSON.stringify(r))}else n[n.length]=t},r.unregisterHandler=function(e,t){l("address","string",e),l("handler","function",t),f();var n=s[e];if(n){var r=n.indexOf(t);r!=-1&&n.splice(r,1);if(n.length==0){var o={type:"unregister",address:e};i.send(JSON.stringify(o)),delete s[e]}}},r.close=function(){f(),u=vertx.EventBus.CLOSING,i.close()},r.readyState=function(){return u},i.onopen=function(){u=vertx.EventBus.OPEN,r.onopen&&r.onopen()},i.onclose=function(){u=vertx.EventBus.CLOSED,r.onclose&&r.onclose()},i.onmessage=function(e){var t=e.data,n=JSON.parse(t),i=n.body,u=n.replyAddress,a=n.address,f;u&&(f=function(e,t){r.send(u,e,t)});var l=s[a];if(l){var c=l.slice(0);for(var h=0;h<c.length;h++)c[h](i,f)}else{var p=o[a];p&&(delete o[u],p(i,f))}}},vertx.EventBus.CONNECTING=0,vertx.EventBus.OPEN=1,vertx.EventBus.CLOSING=2,vertx.EventBus.CLOSED=3,vertx.EventBus});

--- a/ajax/libs/vertx/package.json
+++ b/ajax/libs/vertx/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vertx",
     "filename": "vertxbus.min.js",
-    "version": "1.2.3",
+    "version": "1.3.0",
     "description": "Effortless asynchronous application development for the modern web and enterprise. This library internally uses SockJS to send and receive data to a SockJS vert.x server called the SockJS bridge. http://vertx.io/core_manual_js.html#sockjs-eventbus-bridge",
     "homepage": "http://vertx.io/",
     "keywords": [


### PR DESCRIPTION
Added the latest version (1.3.0) of the Vert.x event bus bridge library.

Got it from the official Vert.x 1.3.0 download package (http://vertx.io/downloads.html, file client/vertxbus.js). Minified version generated with Uglify.
