### PR TITLE
Fix Garlic.js homepage URL.

### DIFF
--- a/ajax/libs/garlic.js/package.json
+++ b/ajax/libs/garlic.js/package.json
@@ -3,7 +3,7 @@
     "filename": "garlic.min.js",
     "version": "0.0.1",
     "description": "Garlic.js allows you to automatically persist your forms' text field values locally, until the form is submitted. This way, your users don't lose any precious data if they accidentally close their tab or browser.",
-    "homepage": "http://guillaumepotier.github.com/Garlic.js/",
+    "homepage": "http://garlicjs.org/",
     "keywords": [
        "html",
        "form",


### PR DESCRIPTION
Broken link on http://cdnjs.com/ to http://guillaumepotier.github.com/Garlic.js/.
