### PR TITLE
added socialshareprivacy

### DIFF
--- a/ajax/libs/jquery.socialshareprivacy/package.json
+++ b/ajax/libs/jquery.socialshareprivacy/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "socialshareprivacy",
+    "name": "jquery.socialshareprivacy",
     "filename": "jquery.socialshareprivacy.min.js",
     "version": "1.4",
     "description": "2 Klicks fuer mehr Datenschutz",


### PR DESCRIPTION
added socialshareprivacy licence MIT is a popular plugin in Germany. 

it adds more privacy as it loads twitter, facebook and google+ share online, when user explicit loads it. 

it also speeds up website as it saves request for twitter, facebook, google+

http://www.heise.de/extras/socialshareprivacy/
