### PR TITLE
Fix jquery.ba-bbq’s dependencies so that jquery-migrate is pulled in for ≥jquery-1.9

### DIFF
--- a/ajax/libs/jquery.ba-bbq/package.json
+++ b/ajax/libs/jquery.ba-bbq/package.json
@@ -21,7 +21,9 @@
        }
    ],
     "dependencies": {
-	"jquery": "1.2.6"
+	"jquery": {
+	    "jquery": ">=1.2.6 <1.9",
+	    "jquery-migrate": ""
+	}
     }
 }
-


### PR DESCRIPTION
...ate for jQuery.browser.

jquery.ba-bbq relies on jQuery.browser being defined. It works fine
with jQuery-1.9 on modern browsers but a JavaScript error is thrown
and logged by the browser when it tries to access
jQuery.browser.msie. Since the official jquery.ba-bbq may not be
updated for some time to support jQuery-1.9 directly, this change
requires jquery-migrate in the case that jquery.ba-bbq’s dependency on
jQuery is satisfied by ≥jquery-1.9.

The version range specifiers are based on
https://npmjs.org/doc/json.html#dependencies and the package OR syntax
is from
http://wiki.commonjs.org/wiki/Packages/1.1#Package_Descriptor_File .
