### PR TITLE
jquery-migrate: Copy dependency on ≥jquery-1.6.4 from upstream package.j...

### DIFF
--- a/ajax/libs/jquery-migrate/package.json
+++ b/ajax/libs/jquery-migrate/package.json
@@ -19,5 +19,8 @@
            "type": "git",
            "url": "https://github.com/jquery/jquery-migrate.git"
        }
-   ]
+   ],
+    "dependencies": {
+	"jquery": ">=1.6.4"
+    },
 }


### PR DESCRIPTION
...son.

Without jquery, loading jquery-migrate will trigger an error based on
`jQuery` not being defined.
