### PR TITLE
Add a license field to elm-runtime.

### DIFF
--- a/ajax/libs/elm-runtime/package.json
+++ b/ajax/libs/elm-runtime/package.json
@@ -4,6 +4,7 @@
     "version": "0.8.0.3",
     "description": "The runtime for the Elm language.",
     "homepage": "http://elm-lang.org/",
+    "license": "BSD3",
     "keywords": [
        "elm",
        "FRP",
@@ -15,5 +16,4 @@
            "url": "https://github.com/evancz/Elm.git"
        } 
    ]
-
 }


### PR DESCRIPTION
Self explanatory - just adding a `license` field that I forgot to add originally.
