### PR TITLE
Trailing comma causes issues in IE7

### DIFF
--- a/ajax/libs/zclip/1.1.2/jquery.zclip.js
+++ b/ajax/libs/zclip/1.1.2/jquery.zclip.js
@@ -373,7 +373,7 @@ var ZeroClipboard = global.ZeroClipboard = require('ZeroClipboard'),
 			copy: null,
 			beforeCopy: null,
 			afterCopy: null,
-			clickAfter: true,
+			clickAfter: true
 		},
 		unique = (function() {
 			var count = 0;


### PR DESCRIPTION
Please remove this trailing comma as it causes issue in IE7. The current work around is to use the minified version of this library.
