### PR TITLE
Create respond-proxy.html

### DIFF
--- a/ajax/libs/respond.js/1.3.0/respond-proxy.html
+++ b/ajax/libs/respond.js/1.3.0/respond-proxy.html
@@ -1,0 +1,13 @@
+<!-- Respond.js: min/max-width media query polyfill. Remote proxy (c) Scott Jehl. MIT/GPLv2 Lic. j.mp/respondjs -->
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8" />
+	<title>Respond JS Proxy</title>
+</head> 
+<body>
+	<script>
+		!function(){var a,b,c,d,e,f;d=function(){var b,c,d,a={};for(b=document.location.toString().split("?")[1].split("&"),c=0;c<b.length;c++)d=b[c].split("="),d[1]=decodeURIComponent(d[1].replace(/\+/g," ")),d[0].search(/\[\]/)>=0?(d[0]=d[0].replace("[]",""),"object"!=typeof a[d[0]]&&(a[d[0]]=[]),a[d[0]].push(d[1])):a[d[0]]=d[1];return a},e=function(a,b){var c=f();c&&(c.open("GET",a,!0),c.onreadystatechange=function(){4!=c.readyState||200!=c.status&&304!=c.status||b(c.responseText)},4!=c.readyState&&c.send())},f=function(){for(var a=!1,b=[function(){return new XMLHttpRequest},function(){return new ActiveXObject("Microsoft.XMLHTTP")},function(){return new ActiveXObject("MSXML2.XMLHTTP.3.0")}],c=b.length;c--;){try{a=b[c]()}catch(d){continue}break}return function(){return a}}(),c=d(),b=c.css,a=c.url,b&&a&&e(b,function(b){window.name=b,window.location.href=a})}();
+	</script>
+</body>
+</html>


### PR DESCRIPTION
This file is used by Respond.js to access CSS files hosted on cloudflare.com CDN in situations when both CSS and Respond.js are served from cloudflare. Without it, Respond.js won't work because of cross-domain communication restrictions.

This is described by Respond.js author below:
https://github.com/scottjehl/Respond/tree/cross-domain#cdnx-domain-setup
