### PR TITLE
add klass library

### DIFF
--- a/ajax/libs/photoswipe/3.0.5/klass.min.js
+++ b/ajax/libs/photoswipe/3.0.5/klass.min.js
@@ -1,0 +1,8 @@
+/**
+  * Klass.js - copyright @dedfat
+  * version 1.0
+  * https://github.com/ded/klass
+  * Follow our software http://twitter.com/dedfat :)
+  * MIT License
+  */
+!function(a,b){function j(a,b){function c(){}c[e]=this[e];var d=this,g=new c,h=f(a),j=h?a:this,k=h?{}:a,l=function(){this.initialize?this.initialize.apply(this,arguments):(b||h&&d.apply(this,arguments),j.apply(this,arguments))};l.methods=function(a){i(g,a,d),l[e]=g;return this},l.methods.call(l,k).prototype.constructor=l,l.extend=arguments.callee,l[e].implement=l.statics=function(a,b){a=typeof a=="string"?function(){var c={};c[a]=b;return c}():a,i(this,a,d);return this};return l}function i(a,b,d){for(var g in b)b.hasOwnProperty(g)&&(a[g]=f(b[g])&&f(d[e][g])&&c.test(b[g])?h(g,b[g],d):b[g])}function h(a,b,c){return function(){var d=this.supr;this.supr=c[e][a];var f=b.apply(this,arguments);this.supr=d;return f}}function g(a){return j.call(f(a)?a:d,a,1)}var c=/xyz/.test(function(){xyz})?/\bsupr\b/:/.*/,d=function(){},e="prototype",f=function(a){return typeof a===b};if(typeof module!="undefined"&&module.exports)module.exports=g;else{var k=a.klass;g.noConflict=function(){a.klass=k;return this},a.klass=g}}(this,"function")


### PR DESCRIPTION
Add klass library to photoswipe. 

This lib is required for photoswipe. The release versions are not the right. They are other versions which don't run. I try to release a right version (see https://github.com/ded/klass/issues/19) but without success.

This library is deliverd with photoswipe 3.0.5.

Please add this library to the photoswipe. 
