### PR TITLE
Improve dependency managment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<a href="http://travis-ci.org/cdnjs/cdnjs"><img src="https://secure.travis-ci.org/cdnjs/cdnjs.png" alt="Build Status" style="max-width:100%;"></a>
+[![Build Status](https://travis-ci.org/cdnjs/cdnjs.png?branch=master)](https://travis-ci.org/cdnjs/cdnjs) [![Dependency Status](https://david-dm.org/cdnjs/cdnjs.png?theme=shields.io)](https://david-dm.org/cdnjs/cdnjs) [![devDependency Status](https://david-dm.org/cdnjs/cdnjs/dev-status.png?theme=shields.io)](https://david-dm.org/cdnjs/cdnjs#info=devDependencies)
 
 # cdnJS Script Repository
 

--- a/package.json
+++ b/package.json
@@ -13,25 +13,23 @@
     "test": "vows"
   },
   "dependencies": {
-    "clean-css": "~0.10.2",
-    "uglify-js": "~2.2.5",
-    "glob": "~3.1.21",
-    "rss": "0.0.4",
-    "underscore": "~1.4.4",
-    "execSync": "0.0.4",
-    "superagent": "~0.15.7",
-    "path": "~0.4.9",
-    "mkdirp": "~0.3.5",
-    "async": "~0.2.9",
-    "lodash": "~2.4.1",
-    "tarball-extract": "0.0.3",
-    "fs-extra": "~0.8.1"
+    "async": "~0.2",
+    "clean-css": "~2.0",
+    "execSync": "~0.0",
+    "fs-extra": "~0.8",
+    "glob": "~3.2",
+    "lodash": "~2.4",
+    "mkdirp": "~0.3",
+    "rss": "~0.3",
+    "superagent": "~0.16",
+    "tarball-extract": "~0.0",
+    "uglify-js": "~2.4",
+    "underscore": "~1.6"
   },
   "devDependencies": {
-    "glob": "3.1.9",
-    "jslint": "0.1.8",
-    "vows-si": "0.7.1",
-    "JSV": "4.0.1"
+    "jslint": "~0.2",
+    "JSV": "~4.0",
+    "vows-si": "~0.7"
   },
   "optionalDependencies": {},
   "engines": {


### PR DESCRIPTION
- Remove duplicate dependencies
- Remove path as it's native module
- Update dependencies
- Avoid setting .patch in dependency version numbers as they may become outdated. Whenever, we can add .patch if it's required (e.g. from ~1.0 to ~1.0.1).
- Add David badges
