### PR TITLE
add missed responsive-nav.css in responsive-nav version 1.0.14

### DIFF
--- a/ajax/libs/responsive-nav.js/1.0.14/responsive-nav.css
+++ b/ajax/libs/responsive-nav.js/1.0.14/responsive-nav.css
@@ -1,0 +1,37 @@
+/*! responsive-nav.js v1.0.14 by @viljamis */
+
+#nav ul {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  display: block;
+  list-style: none;
+}
+
+#nav li {
+  width: 100%;
+  display: block;
+}
+
+.js #nav {
+  clip: rect(0 0 0 0);
+  max-height: 0;
+  position: absolute;
+  display: block;
+  overflow: hidden;
+  zoom: 1;
+}
+
+#nav.opened {
+  max-height: 9999px;
+}
+
+@media screen and (min-width: 40em) {
+  .js #nav {
+    position: relative;
+    max-height: none;
+  }
+  #nav-toggle {
+    display: none;
+  }
+}


### PR DESCRIPTION
Hello, I found that there is a missed file in responsive-nav version 1.0.14 and just fixed it.
