### PR TITLE
Added jquery.serializeJSON [author]

### DIFF
--- a/ajax/libs/jquery.serializeJSON/1.0.2/jquery.serializeJSON.min.js
+++ b/ajax/libs/jquery.serializeJSON/1.0.2/jquery.serializeJSON.min.js
@@ -1,0 +1,10 @@
+/*!
+  SerializeJSON jQuery plugin.
+  https://github.com/marioizquierdo/jquery.serializeJSON
+  version 1.0.2 (Aug 20, 2012)
+
+  Copyright (c) 2012 Mario Izquierdo
+  Dual licensed under the MIT (http://www.opensource.org/licenses/mit-license.php)
+  and GPL (http://www.opensource.org/licenses/gpl-license.php) licenses.
+*/
+(function(b){b.fn.serializeJSON=function(){var d,c;d={};c=this.serializeArray();b.each(c,function(g,e){var f,j,h;f=e.name;j=e.value;h=b.map(f.split("["),function(i){var k;k=i[i.length-1];return k==="]"?i.substring(0,i.length-1):i});if(h[0]===""){h.shift()}b.deepSet(d,h,j)});return d};var a=function(c){return c===Object(c)};b.deepSet=function(c,k,g){if(!k||k.length===0){throw new Error("ArgumentError: keys param expected to be an array with least one key")}var i,d,f,h,j,e;i=k[0];d=k[1];if(d!==undefined&&d!==null){f=k.slice(1);if(i===""){j=c.length-1;e=c[c.length-1];if(a(e)&&!e[d]){i=j}else{c.push({});i=j+1}}if(c[i]===undefined){h=(d===""||!isNaN(parseInt(d,10)))?[]:{};c[i]=h}b.deepSet(c[i],f,g)}else{if(i===""){c.push(g)}else{c[i]=g}}}}(jQuery));

--- a/ajax/libs/jquery.serializeJSON/1.1.0/jquery.serializeJSON.min.js
+++ b/ajax/libs/jquery.serializeJSON/1.1.0/jquery.serializeJSON.min.js
@@ -1,0 +1,9 @@
+/*!
+  SerializeJSON jQuery plugin.
+  https://github.com/marioizquierdo/jquery.serializeJSON
+  version 1.1.0 (Feb 16, 2014)
+
+  Copyright (c) 2012 Mario Izquierdo
+  Dual licensed under the MIT (http://www.opensource.org/licenses/mit-license.php)
+  and GPL (http://www.opensource.org/licenses/gpl-license.php) licenses.
+*/(function(e){"use strict";e.fn.serializeJSON=function(){var t,n;t={};n=this.serializeArray();e.each(n,function(n,r){var i,s,o;i=r.name;s=r.value;o=e.map(i.split("["),function(e){var t;t=e[e.length-1];return t==="]"?e.substring(0,e.length-1):e});o[0]===""&&o.shift();e.deepSet(t,o,s)});return t};var t=function(e){return e===Object(e)},n=function(e){return!isNaN(parseInt(e,10))&&isFinite(e)};e.deepSet=function(r,i,s){if(!i||i.length===0)throw new Error("ArgumentError: keys param expected to be an array with least one key");var o,u,a,f,l,c;o=i[0];u=i[1];if(u!==undefined&&u!==null){a=i.slice(1);if(o===""){l=r.length-1;c=r[r.length-1];if(t(c)&&!c[u])o=l;else{r.push({});o=l+1}}if(r[o]===undefined){f=u===""||n(u)?[]:{};r[o]=f}e.deepSet(r[o],a,s)}else o===""?r.push(s):r[o]=s}})(jQuery);

--- a/ajax/libs/jquery.serializeJSON/1.2.0/jquery.serializeJSON.min.js
+++ b/ajax/libs/jquery.serializeJSON/1.2.0/jquery.serializeJSON.min.js
@@ -1,0 +1,10 @@
+/*!
+  SerializeJSON jQuery plugin.
+  https://github.com/marioizquierdo/jquery.serializeJSON
+  version 1.2.0 (Mar 11, 2014)
+
+  Copyright (c) 2012 Mario Izquierdo
+  Dual licensed under the MIT (http://www.opensource.org/licenses/mit-license.php)
+  and GPL (http://www.opensource.org/licenses/gpl-license.php) licenses.
+*/
+(function(e){"use strict";e.fn.serializeJSON=function(){var t,n;t={};n=this.serializeArray();e.each(n,function(n,r){var i,s,o;i=r.name;s=r.value;o=e.map(i.split("["),function(e){var t;t=e[e.length-1];return t==="]"?e.substring(0,e.length-1):e});if(o[0]===""){o.shift()}e.deepSet(t,o,s)});return t};var t=function(e){return e===Object(e)};var n=function(e){return e===void 0};var r=function(e){return/^[0-9]+$/.test(String(e))};e.deepSet=function(i,s,o){var u,a,f,l,c,h;if(!s||s.length===0){throw new Error("ArgumentError: keys param expected to be an array with least one key")}u=s[0];if(s.length==1){if(u===""){i.push(o)}else{i[u]=o}}else{a=s[1];if(u===""){c=i.length-1;h=i[i.length-1];if(t(h)&&n(h[a])){u=c}else{i.push({});u=c+1}}if(n(i[u])){if(a===""||r(a)){i[u]=[]}else{i[u]={}}}f=s.slice(1);e.deepSet(i[u],f,o)}}})(jQuery)

--- a/ajax/libs/jquery.serializeJSON/package.json
+++ b/ajax/libs/jquery.serializeJSON/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "jquery.serializeJSON",
+  "filename": "jquery.serializeJSON.min.js",
+  "version": "1.2.0",
+  "description": "jQuery plugin that serializes a form into a JavaScript Object with the same format as the default Ruby on Rails request params hash",
+  "homepage": "https://github.com/marioizquierdo/jquery.serializeJSON",
+  "keywords": [
+    "jquery",
+    "serialize",
+    "form",
+    "helper"
+  ],
+  "maintainers": [
+    {
+      "name": "Mario Izquierdo",
+      "email": "tothemario@gmail.com",
+      "web": "https://github.com/marioizquierdo"
+    }
+  ],
+  "repositories": [
+    {
+      "type": "git",
+      "url": "https://github.com/marioizquierdo/jquery.serializeJSON"
+    }
+  ]
+}


### PR DESCRIPTION
https://github.com/marioizquierdo/jquery.serializeJSON
This library helps serializing a form into a JavaScript object, including nested keys.

I added the last version, and other 2 old versions: (latest 1.2.x, 1.1.x and 1.0.x):
- https://github.com/marioizquierdo/jquery.serializeJSON/blob/1.2.0/jquery.serializeJSON.min.js
- https://github.com/marioizquierdo/jquery.serializeJSON/blob/1.1.0/jquery.serializeJSON.min.js
- https://github.com/marioizquierdo/jquery.serializeJSON/blob/1.0.2/jquery.serializeJSON.min.js

Please add to the CDN, then I will update my README to include installing from CDN in the instructions.

Thanks!
