### PR TITLE
Updated ng-dialog: add npm package details

### DIFF
--- a/ajax/libs/ng-dialog/package.json
+++ b/ajax/libs/ng-dialog/package.json
@@ -8,6 +8,20 @@
     "type": "git",
     "url": "https://github.com/likeastore/ngDialog.git"
   },
+  "npmName": "ng-dialog",
+  "npmFileMap": [{
+    "basePath": "/",
+    "files": [
+      "css/ngDialog.css",
+      "css/ngDialog.min.css",
+      "css/ngDialog-theme-default.css",
+      "css/ngDialog-theme-default.min.css",
+      "css/ngDialog-theme-plain.css",
+      "css/ngDialog-theme-plain.min.css",
+      "js/ngDialog.js",
+      "js/ngDialog.min.js"
+    ]
+  }],
   "keywords": [
     "angular",
     "angularjs",


### PR DESCRIPTION
I've updated ng-dialog with npm package info.

All the tests pass.

See https://github.com/likeastore/ngDialog/issues/23
