### PR TITLE
Update package.json

### DIFF
--- a/ajax/libs/codemirror/package.json
+++ b/ajax/libs/codemirror/package.json
@@ -1,22 +1,25 @@
 {
     "name": "codemirror",
-    "filename": "codemirror.min.js",
-    "version":"4.0.3",
-    "main": "codemirror.js",
+    "version":"4.0.4",
+    "main": "lib/codemirror.js",
     "description": "In-browser code editing made bearable",
     "licenses": [{"type": "MIT",
                   "url": "http://codemirror.net/LICENSE"}],
     "directories": {"lib": "./lib"},
     "scripts": {"test": "node ./test/run.js"},
-    "devDependencies": {"node-static": "0.6.0"},
+    "devDependencies": {"node-static": "0.6.0",
+                        "phantomjs": "1.9.2-5"},
     "bugs": "http://github.com/marijnh/CodeMirror/issues",
     "keywords": ["JavaScript", "CodeMirror", "Editor"],
     "homepage": "http://codemirror.net",
     "maintainers":[{"name": "Marijn Haverbeke",
                     "email": "marijnh@gmail.com",
                     "web": "http://marijnhaverbeke.nl"}],
-    "repositories": [{"type": "git",
-                      "url": "http://marijnhaverbeke.nl/git/codemirror"},
-                     {"type": "git",
-                      "url": "https://github.com/marijnh/CodeMirror.git"}]
+    "repository": {"type": "git",
+                   "url": "https://github.com/marijnh/CodeMirror.git"}
+   "npmName": "codemirror",
+   "npmFileMap": [{"basePath": "/lib/",
+                   "files": ["*.+(js|css)"]},
+                  {"basePath": "/",
+                   "files": ["+(addon|theme|mode|keymap)/**/*.+(js|css)"]}]
 }


### PR DESCRIPTION
This adds the auto-update fields, but has the following problems:
- This is not an actual release, yet.
- The upstream does not include minified versions of the css/js, and probably won't.
  - Would this not be a good, and relatively easy, thing to add to the auto-update script? It seems like opt-in of, say, `uglify`, `clean-css` would both be one-liner kind of things, and would save many maintainers effort.

If this were to be accepted, please donate to the EFF... they use temporary wallets, so I can't provide an address, sorry. 
