### PR TITLE
Added npm auto update to 38 libs

### DIFF
--- a/ajax/libs/Faker/package.json
+++ b/ajax/libs/Faker/package.json
@@ -1,26 +1,35 @@
 {
-    "name": "Faker",
-    "filename": "MinFaker.js",
-    "description": "Generate massive amounts of fake contextual data",
-    "version": "0.5.11",
-    "author": "Marak Squires <marak.squires@gmail.com>",
-    "repository": {
-        "type": "git",
-        "url": "http://github.com/Marak/Faker.js.git"
-    },
-    "scripts": {
-        "test": "node_modules/.bin/mocha test/*.*.js"
-    },
-    "devDependencies": {
-        "jshint": "0.9.0",
-        "istanbul": "0.1.25",
-        "mocha": "1.7.4",
-        "node-minify": "*",
-        "optimist" : "0.3.5",
-        "sinon": "1.4.2"
-    },
-    "engine": [
-        "node >=0.1.90"
-    ],
-    "main": "index"
+  "name": "Faker",
+  "filename": "MinFaker.js",
+  "description": "Generate massive amounts of fake contextual data",
+  "version": "0.5.11",
+  "author": "Marak Squires <marak.squires@gmail.com>",
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/Marak/Faker.js.git"
+  },
+  "scripts": {
+    "test": "node_modules/.bin/mocha test/*.*.js"
+  },
+  "devDependencies": {
+    "jshint": "0.9.0",
+    "istanbul": "0.1.25",
+    "mocha": "1.7.4",
+    "node-minify": "*",
+    "optimist": "0.3.5",
+    "sinon": "1.4.2"
+  },
+  "engine": [
+    "node >=0.1.90"
+  ],
+  "main": "index",
+  "npmName": "Faker",
+  "npmFileMap": [
+    {
+      "basePath": "/",
+      "files": [
+        "MinFaker.js"
+      ]
+    }
+  ]
 }

--- a/ajax/libs/angular-ui-router/package.json
+++ b/ajax/libs/angular-ui-router/package.json
@@ -65,5 +65,15 @@
     "load-grunt-tasks": "~0.2.0",
     "grunt-conventional-changelog": "~1.0.0",
     "grunt-ngdocs": "~0.1.7"
-  }
+  },
+  "npmName": "angular-ui-router",
+  "npmFileMap": [
+    {
+      "basePath": "/",
+      "files": [
+        "release/angular-ui-router.min.js",
+        "release/angular-ui-router.js"
+      ]
+    }
+  ]
 }

--- a/ajax/libs/backbone-associations/package.json
+++ b/ajax/libs/backbone-associations/package.json
@@ -1,52 +1,75 @@
 {
-    "name":"backbone-associations",
-    "filename":"backbone-associations-min.js",
-    "description":"Create object hierarchies with Backbone models. Respond to hierarchy changes using regular Backbone events",
-    "url":"https://github.com/dhruvaray/backbone-associations/",
-    "homepage":"http://dhruvaray.github.io/backbone-associations/",
-    "keywords":["Backbone", "association", "associated", "nested", "model", "cyclic graph", "qualified event paths", "relational", "relations"],
-    "author":["Dhruva Ray", "Jaynti Kanani"],
-    "dependencies":{
-        "backbone":">=1.0.0",
-        "underscore":">=1.4.4"
+  "name": "backbone-associations",
+  "filename": "backbone-associations-min.js",
+  "description": "Create object hierarchies with Backbone models. Respond to hierarchy changes using regular Backbone events",
+  "url": "https://github.com/dhruvaray/backbone-associations/",
+  "homepage": "http://dhruvaray.github.io/backbone-associations/",
+  "keywords": [
+    "Backbone",
+    "association",
+    "associated",
+    "nested",
+    "model",
+    "cyclic graph",
+    "qualified event paths",
+    "relational",
+    "relations"
+  ],
+  "author": [
+    "Dhruva Ray",
+    "Jaynti Kanani"
+  ],
+  "dependencies": {
+    "backbone": ">=1.0.0",
+    "underscore": ">=1.4.4"
+  },
+  "devDependencies": {
+    "phantomjs": "0.2.2"
+  },
+  "jam": {
+    "dependencies": {
+      "backbone": ">=1.0.0",
+      "underscore": ">=1.4.4"
     },
-    "devDependencies":{
-        "phantomjs":"0.2.2"
+    "main": "backbone-associations.js",
+    "include": [
+      "backbone-associations.js",
+      "backbone-associations-min.js",
+      "README.md",
+      "CHANGELOG.md"
+    ]
+  },
+  "scripts": {
+    "test": "phantomjs test/lib/runner.js test/test-suite.html?noglobals=true"
+  },
+  "main": "backbone-associations.js",
+  "version": "0.6.1",
+  "repository": "git://github.com/dhruvaray/backbone-associations.git",
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://github.com/dhruvaray/backbone-associations/blob/master/LICENSE.txt"
+    }
+  ],
+  "contributors": [
+    {
+      "name": "Dhruva Ray",
+      "web": "https://github.com/dhruvaray"
     },
-    "jam":{
-        "dependencies":{
-            "backbone":">=1.0.0",
-            "underscore":">=1.4.4"
-        },
-        "main":"backbone-associations.js",
-        "include":[
-            "backbone-associations.js",
-            "backbone-associations-min.js",
-            "README.md",
-            "CHANGELOG.md"
-        ]
-    },
-    "scripts":{
-        "test":"phantomjs test/lib/runner.js test/test-suite.html?noglobals=true"
-    },
-    "main":"backbone-associations.js",
-    "version": "0.6.1",
-    "repository":"git://github.com/dhruvaray/backbone-associations.git",
-    "licenses":[
-        {
-            "type":"MIT",
-            "url":"https://github.com/dhruvaray/backbone-associations/blob/master/LICENSE.txt"
-        }
-    ],
-    "contributors":[
-        {
-            "name":"Dhruva Ray",
-            "web":"https://github.com/dhruvaray"
-        },
-        {
-            "name":"Jaynti Kanani",
-            "web":"https://github.com/jdkanani"
-        }
-    ],
-    "github":"https://github.com/dhruvaray/backbone-associations/"
+    {
+      "name": "Jaynti Kanani",
+      "web": "https://github.com/jdkanani"
+    }
+  ],
+  "github": "https://github.com/dhruvaray/backbone-associations/",
+  "npmName": "backbone-associations",
+  "npmFileMap": [
+    {
+      "basePath": "/",
+      "files": [
+        "backbone-associations-min.js",
+        "backbone-associations.js"
+      ]
+    }
+  ]
 }

--- a/ajax/libs/backbone-react-component/package.json
+++ b/ajax/libs/backbone-react-component/package.json
@@ -51,5 +51,15 @@
       "type": "MIT",
       "url": "https://github.com/magalhas/backbone-react-component/blob/master/LICENSE-MIT"
     }
+  ],
+  "npmName": "backbone-react-component",
+  "npmFileMap": [
+    {
+      "basePath": "/dist",
+      "files": [
+        "/backbone-react-component-min.js",
+        "/backbone-react-component.js"
+      ]
+    }
   ]
 }

--- a/ajax/libs/bean/package.json
+++ b/ajax/libs/bean/package.json
@@ -1,17 +1,32 @@
 {
-    "name": "bean"
-  , "filename": "bean.min.js"
-  , "description": "A small, fast, framework-agnostic event manager"
-  , "version": "1.0.3"
-  , "homepage": "https://github.com/fat/bean"
-  , "authors": [
-        "Jacob Thornton <@fat>"
-      , "Rod Vagg <@rvagg>"
-      , "Dustin Diaz <@ded>"
-    ]
-  , "repository": {
-        "type": "git"
-      , "url": "https://github.com/fat/bean.git"
+  "name": "bean",
+  "filename": "bean.min.js",
+  "description": "A small, fast, framework-agnostic event manager",
+  "version": "1.0.3",
+  "homepage": "https://github.com/fat/bean",
+  "authors": [
+    "Jacob Thornton <@fat>",
+    "Rod Vagg <@rvagg>",
+    "Dustin Diaz <@ded>"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/fat/bean.git"
+  },
+  "keywords": [
+    "ender",
+    "events",
+    "event",
+    "dom"
+  ],
+  "npmName": "bean",
+  "npmFileMap": [
+    {
+      "basePath": "/",
+      "files": [
+        "bean.js",
+        "bean.min.js"
+      ]
     }
-  , "keywords": [ "ender", "events", "event", "dom" ]
+  ]
 }

--- a/ajax/libs/bignumber.js/package.json
+++ b/ajax/libs/bignumber.js/package.json
@@ -1,39 +1,48 @@
 {
-    "name": "bignumber.js",
-    "filename": "bignumber.min.js",
-    "version": "1.3.0",
-    "description": "A library for arbitrary-precision decimal and non-decimal arithmetic",
-    "homepage": "http://mikemcl.github.io/bignumber.js/",
-    "keywords": [
-        "arbitrary",
-        "precision",
-        "arithmetic",
-        "big",
-        "number",
-        "decimal",
-        "float",
-        "biginteger",
-        "bigdecimal",
-        "bignumber",
-        "bigint",
-        "bignum"
-    ],
-    "maintainers": [
-        {
-            "name": "Michael Mclaughlin",
-            "email": "M8ch88l@gmail.com"
-        }
-    ],
-    "licenses": [
-        {
-            "type": "MIT",
-            "url": "https://raw.github.com/MikeMcl/bignumber.js/master/LICENCE"
-        }
-    ],
-    "repositories": [
-        {
-            "type": "git",
-            "url": "https://github.com/MikeMcl/bignumber.js.git"
-        }
-    ]
+  "name": "bignumber.js",
+  "filename": "bignumber.min.js",
+  "version": "1.3.0",
+  "description": "A library for arbitrary-precision decimal and non-decimal arithmetic",
+  "homepage": "http://mikemcl.github.io/bignumber.js/",
+  "keywords": [
+    "arbitrary",
+    "precision",
+    "arithmetic",
+    "big",
+    "number",
+    "decimal",
+    "float",
+    "biginteger",
+    "bigdecimal",
+    "bignumber",
+    "bigint",
+    "bignum"
+  ],
+  "maintainers": [
+    {
+      "name": "Michael Mclaughlin",
+      "email": "M8ch88l@gmail.com"
+    }
+  ],
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://raw.github.com/MikeMcl/bignumber.js/master/LICENCE"
+    }
+  ],
+  "repositories": [
+    {
+      "type": "git",
+      "url": "https://github.com/MikeMcl/bignumber.js.git"
+    }
+  ],
+  "npmName": "bignumber.js",
+  "npmFileMap": [
+    {
+      "basePath": "/",
+      "files": [
+        "bignumber.min.js"
+      ]
+    }
+  ]
 }

--- a/ajax/libs/blueimp-gallery/package.json
+++ b/ajax/libs/blueimp-gallery/package.json
@@ -1,53 +1,81 @@
 {
-    "name": "blueimp-gallery",
-    "filename": "js/blueimp-gallery.js",
-    "version": "2.11.2",
-    "title": "blueimp Gallery",
-    "description": "blueimp Gallery is a touch-enabled, responsive and customizable image and video gallery, carousel and lightbox, optimized for both mobile and desktop web browsers. It features swipe, mouse and keyboard navigation, transition effects, slideshow functionality, fullscreen support and on-demand content loading and can be extended to display additional content types.",
-    "keywords": [
-        "image",
-        "video",
-        "gallery",
-        "carousel",
-        "lightbox",
-        "mobile",
-        "desktop",
-        "touch",
-        "responsive",
-        "swipe",
-        "mouse",
-        "keyboard",
-        "navigation",
-        "transition",
-        "effects",
-        "slideshow",
-        "fullscreen"
-    ],
-    "homepage": "https://github.com/blueimp/Gallery",
-    "author": {
-        "name": "Sebastian Tschan",
-        "url": "https://blueimp.net"
-    },
-    "maintainers": [
-        {
-            "name": "Sebastian Tschan",
-            "url": "https://blueimp.net"
-        }
-    ],
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/blueimp/Gallery.git"
-    },
-    "bugs": "https://github.com/blueimp/Gallery/issues",
-    "licenses": [
-        {
-            "type": "MIT",
-            "url": "http://www.opensource.org/licenses/MIT"
-        }
-    ],
-    "devDependencies": {
-        "uglify-js": "2.4.0",
-        "less": "1.5.0-b3"
+  "name": "blueimp-gallery",
+  "filename": "js/blueimp-gallery.js",
+  "version": "2.11.2",
+  "title": "blueimp Gallery",
+  "description": "blueimp Gallery is a touch-enabled, responsive and customizable image and video gallery, carousel and lightbox, optimized for both mobile and desktop web browsers. It features swipe, mouse and keyboard navigation, transition effects, slideshow functionality, fullscreen support and on-demand content loading and can be extended to display additional content types.",
+  "keywords": [
+    "image",
+    "video",
+    "gallery",
+    "carousel",
+    "lightbox",
+    "mobile",
+    "desktop",
+    "touch",
+    "responsive",
+    "swipe",
+    "mouse",
+    "keyboard",
+    "navigation",
+    "transition",
+    "effects",
+    "slideshow",
+    "fullscreen"
+  ],
+  "homepage": "https://github.com/blueimp/Gallery",
+  "author": {
+    "name": "Sebastian Tschan",
+    "url": "https://blueimp.net"
+  },
+  "maintainers": [
+    {
+      "name": "Sebastian Tschan",
+      "url": "https://blueimp.net"
     }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/blueimp/Gallery.git"
+  },
+  "bugs": "https://github.com/blueimp/Gallery/issues",
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://www.opensource.org/licenses/MIT"
+    }
+  ],
+  "devDependencies": {
+    "uglify-js": "2.4.0",
+    "less": "1.5.0-b3"
+  },
+  "npmName": "blueimp-gallery",
+  "npmFileMap": [
+    {
+      "basePath": "/",
+      "files": [
+        "css/blueimp-gallery-indicator.css",
+        "css/blueimp-gallery-video.css",
+        "css/blueimp-gallery.css",
+        "css/blueimp-gallery.min.css",
+        "img/error.png",
+        "img/error.svg",
+        "img/play-pause.png",
+        "img/loading.gif",
+        "img/play-pause.svg",
+        "img/video-play.png",
+        "img/video-play.svg",
+        "js/blueimp-gallery-fullscreen.js",
+        "js/blueimp-gallery-indicator.js",
+        "js/blueimp-gallery-video.js",
+        "js/blueimp-gallery-vimeo.js",
+        "js/blueimp-gallery-youtube.js",
+        "js/blueimp-gallery.js",
+        "js/blueimp-gallery.min.js",
+        "js/blueimp-helper.js",
+        "js/jquery.blueimp-gallery.js",
+        "js/jquery.blueimp-gallery.min.js"
+      ]
+    }
+  ]
 }
-

--- a/ajax/libs/chroma-js/package.json
+++ b/ajax/libs/chroma-js/package.json
@@ -1,26 +1,46 @@
 {
-    "name"         : "chroma-js",
-    "filename"     : "chroma.min.js", 
-    "description"  : "JavaScript library for color conversions",
-    "version"      : "0.5.2",
-    "author"       : "Gregor Aisch",
-    "homepage"     : "https://github.com/gka/chroma.js",
-    "keywords"     : ["color"],
-    "maintainers"  : [
-        { "name": "Klemen Slavič", "email": "klemen@celtra.com", "web": "http://about.me/klemen.slavic" },
-        { "name": "Gregor Aisch", "email": "mail@driven-by-data.net", "web": "http://driven-by-data.net" }
-    ],
-    "bugs"         : "https://github.com/gka/chroma.js/issues",
-    "repository" : 
-       { "type": "git", "url" : "git://github.com/gka/chroma.js.git" }
-    ,
-    "main"         : "chroma.js",
-    "scripts"      : {
-        "compile": "./build.sh"
+  "name": "chroma-js",
+  "filename": "chroma.min.js",
+  "description": "JavaScript library for color conversions",
+  "version": "0.5.2",
+  "author": "Gregor Aisch",
+  "homepage": "https://github.com/gka/chroma.js",
+  "keywords": [
+    "color"
+  ],
+  "maintainers": [
+    {
+      "name": "Klemen Slavič",
+      "email": "klemen@celtra.com",
+      "web": "http://about.me/klemen.slavic"
     },
-    "devDependencies": {
-        "uglify-js"     : "2.x",
-        "coffee-script" : "1.2",
-        "vows": "0.7.x"
+    {
+      "name": "Gregor Aisch",
+      "email": "mail@driven-by-data.net",
+      "web": "http://driven-by-data.net"
     }
+  ],
+  "bugs": "https://github.com/gka/chroma.js/issues",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/gka/chroma.js.git"
+  },
+  "main": "chroma.js",
+  "scripts": {
+    "compile": "./build.sh"
+  },
+  "devDependencies": {
+    "uglify-js": "2.x",
+    "coffee-script": "1.2",
+    "vows": "0.7.x"
+  },
+  "npmName": "chroma-js",
+  "npmFileMap": [
+    {
+      "basePath": "/",
+      "files": [
+        "chroma.min.js"
+      ]
+    }
+  ]
 }

--- a/ajax/libs/crossfilter/package.json
+++ b/ajax/libs/crossfilter/package.json
@@ -37,5 +37,15 @@
   },
   "scripts": {
     "test": "./node_modules/.bin/vows"
-  }
+  },
+  "npmName": "crossfilter",
+  "npmFileMap": [
+    {
+      "basePath": "/",
+      "files": [
+        "crossfilter.js",
+        "crossfilter.min.js"
+      ]
+    }
+  ]
 }

--- a/ajax/libs/crossroads/package.json
+++ b/ajax/libs/crossroads/package.json
@@ -1,44 +1,54 @@
 {
-    "name": "crossroads",
-    "filename": "crossroads.min.js",
-    "description": "Flexible router which can be used in multiple environments",
-    "keywords": [
-        "routes",
-        "event",
-        "observer",
-        "routing",
-        "router"
-    ],
-    "homepage": "http://millermedeiros.github.com/crossroads.js/",
-    "version": "0.12.0",
-    "author": {
-        "name": "Miller Medeiros",
-        "url": "http://blog.millermedeiros.com/"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/millermedeiros/crossroads.js.git"
-    },
-    "main": "dist/crossroads.js",
-    "bugs": "https://github.com/millermedeiros/crossroads.js/issues",
-    "licenses": [
-        {
-            "type": "MIT",
-            "url": "http://www.opensource.org/licenses/mit-license.php"
-        }
-    ],
-    "dependencies": {
-        "signals": "<2.0"
-    },
-    "devDependencies": {
-        "uglify-js": "~1.2.3",
-        "jasmine-node": "1.0.x"
-    },
-    "scripts": {
-        "pretest": "node build",
-        "test": "node node_modules/.bin/jasmine-node dev/tests/spec"
-    },
-    "readme": "[![Build Status](https://secure.travis-ci.org/millermedeiros/crossroads.js.png)](https://travis-ci.org/millermedeiros/crossroads.js)\n\n---\n\n![Crossroads - JavaScript Routes](https://github.com/millermedeiros/crossroads.js/raw/master/_assets/crossroads_logo.png)\n\n\n## Introduction ##\n\nCrossroads.js is a routing library inspired by URL Route/Dispatch utilities present on frameworks like Rails, Pyramid, Django, CakePHP, CodeIgniter, etc...\nIt parses a string input and decides which action should be executed by matching the string against multiple patterns.\n\nIf used properly it can reduce code complexity by decoupling objects and also by abstracting navigation paths.\n\nSee [project page](http://millermedeiros.github.com/crossroads.js/) for documentation and more details.\n\n\n\n\n## Links ##\n\n - [Project page and documentation](http://millermedeiros.github.com/crossroads.js/)\n - [Usage examples](https://github.com/millermedeiros/crossroads.js/wiki/Examples)\n - [Changelog](https://github.com/millermedeiros/crossroads.js/blob/master/CHANGELOG.md)\n\n\n\n## Dependencies ##\n\n**This library requires [JS-Signals](http://millermedeiros.github.com/js-signals/) to work.**\n\n\n\n## License ##\n\n[MIT License](http://www.opensource.org/licenses/mit-license.php)\n\n\n\n## Distribution Files ##\n\nFiles inside `dist` folder.\n\n * crossroads.js : Uncompressed source code with comments.\n * crossroads.min.js : Compressed code.\n\nYou can install Crossroads on Node.js using [NPM](http://npmjs.org/)\n\n    npm install crossroads\n\n\n\n## Repository Structure ##\n\n### Folder Structure ###\n\n    dev       ->  development files\n    |- lib          ->  3rd-party libraries\n    |- src          ->  source files\n    |- tests        ->  unit tests\n    dist      ->  distribution files\n\n### Branches ###\n\n    master      ->  always contain code from the latest stable version\n    release-**  ->  code canditate for the next stable version (alpha/beta)\n    dev         ->  main development branch (nightly)\n    gh-pages    ->  project page\n    **other**   ->  features/hotfixes/experimental, probably non-stable code\n\n\n\n## Building your own ##\n\nThis project uses [Node.js](http://nodejs.org/) for the build process. If for some reason you need to build a custom version install Node.js and run:\n\n    node build\n\nThis will delete all JS files inside the `dist` folder, merge/update/compress source files and copy the output to the `dist` folder.\n\n**IMPORTANT:** `dist` folder always contain the latest version, regular users should **not** need to run build task.\n\n\n\n## Running unit tests ##\n\n### On the browser ###\n\nOpen `dev/tests/spec_runner-dist.html` on your browser.\n\n`spec_runner-dist` tests `dist/crossroads.js` and `spec_runner-dev` tests files inside\n`dev/src` - they all run the same specs.\n\n\n### On Node.js ###\n\nInstall [npm](http://npmjs.org) and run:\n\n```\nnpm install --dev\nnpm test\n```\n\nEach time you run `npm test` the files inside the `dist` folder will be updated\n(it executes `node build` as a `pretest` script).\n",
-    "_id": "crossroads@0.12.0",
-    "_from": "crossroads"
+  "name": "crossroads",
+  "filename": "crossroads.min.js",
+  "description": "Flexible router which can be used in multiple environments",
+  "keywords": [
+    "routes",
+    "event",
+    "observer",
+    "routing",
+    "router"
+  ],
+  "homepage": "http://millermedeiros.github.com/crossroads.js/",
+  "version": "0.12.0",
+  "author": {
+    "name": "Miller Medeiros",
+    "url": "http://blog.millermedeiros.com/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/millermedeiros/crossroads.js.git"
+  },
+  "main": "dist/crossroads.js",
+  "bugs": "https://github.com/millermedeiros/crossroads.js/issues",
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://www.opensource.org/licenses/mit-license.php"
+    }
+  ],
+  "dependencies": {
+    "signals": "<2.0"
+  },
+  "devDependencies": {
+    "uglify-js": "~1.2.3",
+    "jasmine-node": "1.0.x"
+  },
+  "scripts": {
+    "pretest": "node build",
+    "test": "node node_modules/.bin/jasmine-node dev/tests/spec"
+  },
+  "readme": "[![Build Status](https://secure.travis-ci.org/millermedeiros/crossroads.js.png)](https://travis-ci.org/millermedeiros/crossroads.js)\n\n---\n\n![Crossroads - JavaScript Routes](https://github.com/millermedeiros/crossroads.js/raw/master/_assets/crossroads_logo.png)\n\n\n## Introduction ##\n\nCrossroads.js is a routing library inspired by URL Route/Dispatch utilities present on frameworks like Rails, Pyramid, Django, CakePHP, CodeIgniter, etc...\nIt parses a string input and decides which action should be executed by matching the string against multiple patterns.\n\nIf used properly it can reduce code complexity by decoupling objects and also by abstracting navigation paths.\n\nSee [project page](http://millermedeiros.github.com/crossroads.js/) for documentation and more details.\n\n\n\n\n## Links ##\n\n - [Project page and documentation](http://millermedeiros.github.com/crossroads.js/)\n - [Usage examples](https://github.com/millermedeiros/crossroads.js/wiki/Examples)\n - [Changelog](https://github.com/millermedeiros/crossroads.js/blob/master/CHANGELOG.md)\n\n\n\n## Dependencies ##\n\n**This library requires [JS-Signals](http://millermedeiros.github.com/js-signals/) to work.**\n\n\n\n## License ##\n\n[MIT License](http://www.opensource.org/licenses/mit-license.php)\n\n\n\n## Distribution Files ##\n\nFiles inside `dist` folder.\n\n * crossroads.js : Uncompressed source code with comments.\n * crossroads.min.js : Compressed code.\n\nYou can install Crossroads on Node.js using [NPM](http://npmjs.org/)\n\n    npm install crossroads\n\n\n\n## Repository Structure ##\n\n### Folder Structure ###\n\n    dev       ->  development files\n    |- lib          ->  3rd-party libraries\n    |- src          ->  source files\n    |- tests        ->  unit tests\n    dist      ->  distribution files\n\n### Branches ###\n\n    master      ->  always contain code from the latest stable version\n    release-**  ->  code canditate for the next stable version (alpha/beta)\n    dev         ->  main development branch (nightly)\n    gh-pages    ->  project page\n    **other**   ->  features/hotfixes/experimental, probably non-stable code\n\n\n\n## Building your own ##\n\nThis project uses [Node.js](http://nodejs.org/) for the build process. If for some reason you need to build a custom version install Node.js and run:\n\n    node build\n\nThis will delete all JS files inside the `dist` folder, merge/update/compress source files and copy the output to the `dist` folder.\n\n**IMPORTANT:** `dist` folder always contain the latest version, regular users should **not** need to run build task.\n\n\n\n## Running unit tests ##\n\n### On the browser ###\n\nOpen `dev/tests/spec_runner-dist.html` on your browser.\n\n`spec_runner-dist` tests `dist/crossroads.js` and `spec_runner-dev` tests files inside\n`dev/src` - they all run the same specs.\n\n\n### On Node.js ###\n\nInstall [npm](http://npmjs.org) and run:\n\n```\nnpm install --dev\nnpm test\n```\n\nEach time you run `npm test` the files inside the `dist` folder will be updated\n(it executes `node build` as a `pretest` script).\n",
+  "_id": "crossroads@0.12.0",
+  "_from": "crossroads",
+  "npmName": "crossroads",
+  "npmFileMap": [
+    {
+      "basePath": "/",
+      "files": [
+        "dist/crossroads.js",
+        "dist/crossroads.min.js"
+      ]
+    }
+  ]
 }

--- a/ajax/libs/cubism/package.json
+++ b/ajax/libs/cubism/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cubism",
-  "filename":"cubism.v1.min.js",
+  "filename": "cubism.v1.min.js",
   "version": "1.2.2",
   "description": "A JavaScript library for time series visualization.",
   "keywords": [
@@ -23,5 +23,15 @@
   "devDependencies": {
     "vows": "0.6.1",
     "uglify-js": "1.2.5"
-  }
+  },
+  "npmName": "cubism",
+  "npmFileMap": [
+    {
+      "basePath": "/",
+      "files": [
+        "cubism.v1.js",
+        "cubism.v1.min.js"
+      ]
+    }
+  ]
 }

--- a/ajax/libs/dc/package.json
+++ b/ajax/libs/dc/package.json
@@ -23,5 +23,16 @@
   "dependencies": {
     "crossfilter": "1.x",
     "d3": "3.x"
-  }
+  },
+  "npmName": "dc",
+  "npmFileMap": [
+    {
+      "basePath": "/",
+      "files": [
+        "dc.css",
+        "dc.min.js",
+        "dc.js"
+      ]
+    }
+  ]
 }

--- a/ajax/libs/depot/package.json
+++ b/ajax/libs/depot/package.json
@@ -1,11 +1,23 @@
 {
-    "name": "depot",
-    "filename": "depot.min.js",
-    "version": "0.1.6",
-    "description": "depot.js is a namespaced localStorage wrapper with a simple API.",
-    "homepage": "https://github.com/mkuklis/depot.js",
-    "repositories": [{
+  "name": "depot",
+  "filename": "depot.min.js",
+  "version": "0.1.6",
+  "description": "depot.js is a namespaced localStorage wrapper with a simple API.",
+  "homepage": "https://github.com/mkuklis/depot.js",
+  "repositories": [
+    {
       "type": "git",
       "url": "https://github.com/mkuklis/depot.js"
-    }]
+    }
+  ],
+  "npmName": "depot",
+  "npmFileMap": [
+    {
+      "basePath": "/",
+      "files": [
+        "depot.js",
+        "depot.min.js"
+      ]
+    }
+  ]
 }

--- a/ajax/libs/dropzone/package.json
+++ b/ajax/libs/dropzone/package.json
@@ -1,24 +1,42 @@
 {
-    "name": "dropzone",
-    "filename": "dropzone.min.js",
-    "version": "3.8.2",
-    "description": "Drag'n'drop file uploads with image previews",
-    "homepage": "http://www.dropzonejs.com/",
-    "keywords": [
-       "html5",
-       "file",
-       "upload"
-   ],
-   "maintainers": [
-       {
-           "name": "Matias Meno",
-           "web": "https://github.com/enyo"
-       }
-   ],
-   "repositories": [
-       {
-           "type": "git",
-           "url": "git://github.com/enyo/dropzone.git"
-       }
-   ]
+  "name": "dropzone",
+  "filename": "dropzone.min.js",
+  "version": "3.8.2",
+  "description": "Drag'n'drop file uploads with image previews",
+  "homepage": "http://www.dropzonejs.com/",
+  "keywords": [
+    "html5",
+    "file",
+    "upload"
+  ],
+  "maintainers": [
+    {
+      "name": "Matias Meno",
+      "web": "https://github.com/enyo"
+    }
+  ],
+  "repositories": [
+    {
+      "type": "git",
+      "url": "git://github.com/enyo/dropzone.git"
+    }
+  ],
+  "npmName": "dropzone",
+  "npmFileMap": [
+    {
+      "basePath": "/downloads/",
+      "files": [
+        "css/basic.css",
+        "css/dropzone.css",
+        "css/stylus/basic.styl",
+        "css/stylus/dropzone.styl",
+        "dropzone-amd-module.js",
+        "dropzone-amd-module.min.js",
+        "dropzone.js",
+        "dropzone.min.js",
+        "images/spritemap.png",
+        "images/spritemap@2x.png"
+      ]
+    }
+  ]
 }

--- a/ajax/libs/es5-shim/package.json
+++ b/ajax/libs/es5-shim/package.json
@@ -1,33 +1,46 @@
 {
-    "name": "es5-shim",
-    "filename": "es5-shim.min.js",
-    "version": "2.3.0",
-    "description": "ECMAScript 5 compatibility shims for legacy JavaScript engines",
-    "homepage": "https://github.com/es-shims/es5-shim",
-    "keywords": [
-       "es5",
-       "ECMAScript 5",
-       "shim",
-       "compatibility",
-       "modernization"
-    ],
-    "maintainers": [
-        {
-            "name": "Kristopher Michael Kowal",
-            "email": "rfobic@gmail.com",
-            "web": "http://jeditoolkit.com/"
-        },
-        {
-            "name": "Jordan Harband",
-            "email": "ljharb@gmail.com",
-            "web": "https://twitter.com/ljharb"
-        }
-    ],
-    "repositories": [
-        {
-            "type": "git",
-            "url": "https://github.com/es-shims/es5-shim"
-        }
-    ]
+  "name": "es5-shim",
+  "filename": "es5-shim.min.js",
+  "version": "2.3.0",
+  "description": "ECMAScript 5 compatibility shims for legacy JavaScript engines",
+  "homepage": "https://github.com/es-shims/es5-shim",
+  "keywords": [
+    "es5",
+    "ECMAScript 5",
+    "shim",
+    "compatibility",
+    "modernization"
+  ],
+  "maintainers": [
+    {
+      "name": "Kristopher Michael Kowal",
+      "email": "rfobic@gmail.com",
+      "web": "http://jeditoolkit.com/"
+    },
+    {
+      "name": "Jordan Harband",
+      "email": "ljharb@gmail.com",
+      "web": "https://twitter.com/ljharb"
+    }
+  ],
+  "repositories": [
+    {
+      "type": "git",
+      "url": "https://github.com/es-shims/es5-shim"
+    }
+  ],
+  "npmName": "es5-shim",
+  "npmFileMap": [
+    {
+      "basePath": "/",
+      "files": [
+        "es5-sham.map",
+        "es5-sham.js",
+        "es5-sham.min.js",
+        "es5-shim.js",
+        "es5-shim.map",
+        "es5-shim.min.js"
+      ]
+    }
+  ]
 }
-

--- a/ajax/libs/eve.js/package.json
+++ b/ajax/libs/eve.js/package.json
@@ -1,19 +1,28 @@
 {
-	"name": "eve.js",
-	"filename": "eve.min.js",
-	"version": "0.8.4",
-	"description": "A JavaScript meta-framework for scoped event delegation.",
-	"homepage": "http://evejs.com",
-	"maintainers": [
-		{
-			"name": "Michelle Steigerwalt",
-			"web": "http://msteigerwalt.com"
-		}
-	],
-	"repositories": [
-		{
-			"type": "git",
-			"url": "https://github.com/Yuffster/Eve.js"
-	   }
-	]
+  "name": "eve.js",
+  "filename": "eve.min.js",
+  "version": "0.8.4",
+  "description": "A JavaScript meta-framework for scoped event delegation.",
+  "homepage": "http://evejs.com",
+  "maintainers": [
+    {
+      "name": "Michelle Steigerwalt",
+      "web": "http://msteigerwalt.com"
+    }
+  ],
+  "repositories": [
+    {
+      "type": "git",
+      "url": "https://github.com/Yuffster/Eve.js"
+    }
+  ],
+  "npmName": "eve.js",
+  "npmFileMap": [
+    {
+      "basePath": "/",
+      "files": [
+        "eve.min.js"
+      ]
+    }
+  ]
 }

--- a/ajax/libs/font-awesome/package.json
+++ b/ajax/libs/font-awesome/package.json
@@ -1,10 +1,27 @@
 {
-    "name": "font-awesome",
-    "filename": "css/font-awesome.min.css",
-    "version": "4.0.3",
-    "description": "Font Awesome",
-    "homepage": "http://fontawesome.io/",
-    "keywords": [
-       "css", "font", "icons"
-    ]
+  "name": "font-awesome",
+  "filename": "css/font-awesome.min.css",
+  "version": "4.0.3",
+  "description": "Font Awesome",
+  "homepage": "http://fontawesome.io/",
+  "keywords": [
+    "css",
+    "font",
+    "icons"
+  ],
+  "npmName": "font-awesome",
+  "npmFileMap": [
+    {
+      "basePath": "/",
+      "files": [
+        "css/font-awesome.css",
+        "css/font-awesome.min.css",
+        "fonts/FontAwesome.otf",
+        "fonts/fontawesome-webfont.eot",
+        "fonts/fontawesome-webfont.woff",
+        "fonts/fontawesome-webfont.ttf",
+        "fonts/fontawesome-webfont.svg"
+      ]
+    }
+  ]
 }

--- a/ajax/libs/jsoneditor/package.json
+++ b/ajax/libs/jsoneditor/package.json
@@ -1,33 +1,46 @@
 {
-    "name": "jsoneditor",
-    "filename": "jsoneditor-min.js",
-    "version": "2.3.6",
-    "description": "JSON Editor Online is a web-based tool to view, edit, and format JSON. It shows your data side by side in a clear, editable treeview and in formatted plain text.",
-    "homepage": "http://jsoneditoronline.org",
-    "keywords": [
-        "json",
-        "html",
-        "editor"
-    ],
-    "licenses": [
-        {
-            "type": "Apache License 2.0",
-            "url": "http://www.apache.org/licenses/"
-        }
-    ],
-    "author": {
-        "name": "Jos de Jong",
-        "web": "http://github.com/wjosdejong"
-    },
-    "maintainers": [
-        {
-            "name": "Jos de Jong",
-            "web": "http://github.com/wjosdejong"
-        }
-    ],
-    "bugs": "http://github.com/wjosdejong/jsoneditoronline/issues",
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/wjosdejong/jsoneditoronline.git"
+  "name": "jsoneditor",
+  "filename": "jsoneditor-min.js",
+  "version": "2.3.6",
+  "description": "JSON Editor Online is a web-based tool to view, edit, and format JSON. It shows your data side by side in a clear, editable treeview and in formatted plain text.",
+  "homepage": "http://jsoneditoronline.org",
+  "keywords": [
+    "json",
+    "html",
+    "editor"
+  ],
+  "licenses": [
+    {
+      "type": "Apache License 2.0",
+      "url": "http://www.apache.org/licenses/"
     }
+  ],
+  "author": {
+    "name": "Jos de Jong",
+    "web": "http://github.com/wjosdejong"
+  },
+  "maintainers": [
+    {
+      "name": "Jos de Jong",
+      "web": "http://github.com/wjosdejong"
+    }
+  ],
+  "bugs": "http://github.com/wjosdejong/jsoneditoronline/issues",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/wjosdejong/jsoneditoronline.git"
+  },
+  "npmName": "jsoneditor",
+  "npmFileMap": [
+    {
+      "basePath": "/",
+      "files": [
+        "img/jsoneditor-icons.png",
+        "jsoneditor-min.css",
+        "jsoneditor-min.js",
+        "jsoneditor.css",
+        "jsoneditor.js"
+      ]
+    }
+  ]
 }

--- a/ajax/libs/jszip/package.json
+++ b/ajax/libs/jszip/package.json
@@ -1,25 +1,37 @@
 {
-    "name": "jszip",
-    "filename": "jszip.js",
-    "version": "2.0.0",
-    "description": "Create, read and edit .zip files with Javascript",
-    "homepage": "http://stuk.github.io/jszip/",
-    "keywords": [
-       "zip",
+  "name": "jszip",
+  "filename": "jszip.js",
+  "version": "2.0.0",
+  "description": "Create, read and edit .zip files with Javascript",
+  "homepage": "http://stuk.github.io/jszip/",
+  "keywords": [
+    "zip",
     "deflate",
     "inflate"
-   ],
-   "bugs": "https://github.com/Stuk/jszip/issues",
-   "maintainers": [
-       {
-           "name": "Stuart Knightley",
-           "web": "https://github.com/Stuk" 
-       }
-   ],
-   "repositories": [
-       {
-           "type": "git",
-           "url": "https://github.com/Stuk/jszip" 
-       } 
-   ]
+  ],
+  "bugs": "https://github.com/Stuk/jszip/issues",
+  "maintainers": [
+    {
+      "name": "Stuart Knightley",
+      "web": "https://github.com/Stuk"
+    }
+  ],
+  "repositories": [
+    {
+      "type": "git",
+      "url": "https://github.com/Stuk/jszip"
+    }
+  ],
+  "npmName": "jszip",
+  "npmFileMap": [
+    {
+      "basePath": "/",
+      "files": [
+        "jszip-deflate.js",
+        "jszip-inflate.js",
+        "jszip-load.js",
+        "jszip.js"
+      ]
+    }
+  ]
 }

--- a/ajax/libs/klass/package.json
+++ b/ajax/libs/klass/package.json
@@ -1,22 +1,31 @@
 {
-    "name": "klass",
-    "filename": "klass.js",
-    "version": "1.3.1",
-    "description": "An expressive, cross platform JavaScript Class provider with a classical interface to prototypal inheritance.",
-    "homepage": "http://dustindiaz.com/klass",
-    "keywords": [
-        "javascript"
-    ],
-    "maintainers": [
-        {
-            "name": "Dustin Diaz"
-        }
-    ],
-   "repository": [
-       {
-           "type": "git",
-           "url": "https://github.com/ded/klass.git"
-       }
-   ]
+  "name": "klass",
+  "filename": "klass.js",
+  "version": "1.3.1",
+  "description": "An expressive, cross platform JavaScript Class provider with a classical interface to prototypal inheritance.",
+  "homepage": "http://dustindiaz.com/klass",
+  "keywords": [
+    "javascript"
+  ],
+  "maintainers": [
+    {
+      "name": "Dustin Diaz"
+    }
+  ],
+  "repository": [
+    {
+      "type": "git",
+      "url": "https://github.com/ded/klass.git"
+    }
+  ],
+  "npmName": "klass",
+  "npmFileMap": [
+    {
+      "basePath": "/",
+      "files": [
+        "klass.js",
+        "klass.min.js"
+      ]
+    }
+  ]
 }
-

--- a/ajax/libs/knockback/package.json
+++ b/ajax/libs/knockback/package.json
@@ -1,18 +1,27 @@
 {
-    "name": "knockback",
-    "filename": "knockback.min.js",
-    "version": "0.17.2",
-    "description": "Knockback brings Knockout.js magic to Backbone.js",
-    "url": "http://kmalakoff.github.io/knockback/",
-    "author": "Kevin Malakoff",
-    "keywords": [
-        "mvvm",
-        "ui",
-        "templating"
-    ],
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/kmalakoff/knockback.git"
-    },
-    "bugs": "https://github.com/kmalakoff/knockback/issues"
+  "name": "knockback",
+  "filename": "knockback.min.js",
+  "version": "0.17.2",
+  "description": "Knockback brings Knockout.js magic to Backbone.js",
+  "url": "http://kmalakoff.github.io/knockback/",
+  "author": "Kevin Malakoff",
+  "keywords": [
+    "mvvm",
+    "ui",
+    "templating"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kmalakoff/knockback.git"
+  },
+  "bugs": "https://github.com/kmalakoff/knockback/issues",
+  "npmName": "knockback",
+  "npmFileMap": [
+    {
+      "basePath": "/",
+      "files": [
+        "knockback.min.js"
+      ]
+    }
+  ]
 }

--- a/ajax/libs/leapjs/package.json
+++ b/ajax/libs/leapjs/package.json
@@ -5,16 +5,28 @@
   "description": "A JavaScript client for the LeapMotion.",
   "homepage": "http://github.com/leapmotion/leapjs",
   "keywords": [
-  "graphics",
-  "leap"
+    "graphics",
+    "leap"
   ],
   "maintainers": [
-    { "name": "joshbuddy", "email": "josh@leapmotion.com" }
+    {
+      "name": "joshbuddy",
+      "email": "josh@leapmotion.com"
+    }
   ],
   "repositories": [
     {
       "type": "git",
       "url": "https://github.com/leapmotion/leapjs.git"
+    }
+  ],
+  "npmName": "leapjs",
+  "npmFileMap": [
+    {
+      "basePath": "/",
+      "files": [
+        "leap.min.js"
+      ]
     }
   ]
 }

--- a/ajax/libs/minitranslate/package.json
+++ b/ajax/libs/minitranslate/package.json
@@ -2,10 +2,12 @@
   "name": "minitranslate",
   "filename": "minitranslate.min.js",
   "version": "0.6.0",
-  "maintainers": [{
-    "name": "Bryce Dorn",
-    "web": "http://bryce.io"
-  }],
+  "maintainers": [
+    {
+      "name": "Bryce Dorn",
+      "web": "http://bryce.io"
+    }
+  ],
   "description": "A lightweight way to change words into other words.",
   "homepage": "http://bryce.io/minitranslate",
   "repository": {
@@ -17,5 +19,15 @@
     "translate",
     "translator",
     "minitranslate"
+  ],
+  "npmName": "minitranslate",
+  "npmFileMap": [
+    {
+      "basePath": "/",
+      "files": [
+        "js/minitranslate.js",
+        "js/minitranslate.min.js"
+      ]
+    }
   ]
 }

--- a/ajax/libs/moment-timezone/package.json
+++ b/ajax/libs/moment-timezone/package.json
@@ -1,24 +1,34 @@
 {
-    "name": "moment-timezone",
-    "filename": "moment-timezone.min.js",
-    "version": "0.0.3",
-    "description": "Timezone plugin for Moment.js.",
-    "homepage": "http://momentjs.com/timezone",
-    "keywords": [
-        "date",
-        "moment",
-        "timezone",
-        "time"
-    ],
-    "maintainers": [
-        {
-            "name": "Tim Wood"
-        }
-    ],
-   "repositories": [
-       {
-           "type": "git",
-           "url": "https://github.com/timrwood/moment-timezone.git"
-       }
-   ]
+  "name": "moment-timezone",
+  "filename": "moment-timezone.min.js",
+  "version": "0.0.3",
+  "description": "Timezone plugin for Moment.js.",
+  "homepage": "http://momentjs.com/timezone",
+  "keywords": [
+    "date",
+    "moment",
+    "timezone",
+    "time"
+  ],
+  "maintainers": [
+    {
+      "name": "Tim Wood"
+    }
+  ],
+  "repositories": [
+    {
+      "type": "git",
+      "url": "https://github.com/timrwood/moment-timezone.git"
+    }
+  ],
+  "npmName": "moment-timezone",
+  "npmFileMap": [
+    {
+      "basePath": "/",
+      "files": [
+        "moment-timezone.js",
+        "min/moment-timezone.min.js"
+      ]
+    }
+  ]
 }

--- a/ajax/libs/primish/package.json
+++ b/ajax/libs/primish/package.json
@@ -3,17 +3,35 @@
   "version": "0.3.4",
   "filename": "primish-min.js",
   "description": "A portable Class implementation in javascript, forked from MooTools Prime and created for the web",
-  "keywords": ["class","mootools","prime","primish"],
+  "keywords": [
+    "class",
+    "mootools",
+    "prime",
+    "primish"
+  ],
   "repository": "https://github.com/DimitarChristoff/primish",
-  "contributors": [{
-    "name": "Dimitar Christoff",
-    "email": "christoff@gmail.com"
-  }, {
-    "name": "Simon Smith",
-    "email": "me@simonsmith.io"
-  }, {
-    "name": "Valerio Pioretti",
-    "email": "kamicane@gmail.com"
-  }],
-  "license": "MIT"
+  "contributors": [
+    {
+      "name": "Dimitar Christoff",
+      "email": "christoff@gmail.com"
+    },
+    {
+      "name": "Simon Smith",
+      "email": "me@simonsmith.io"
+    },
+    {
+      "name": "Valerio Pioretti",
+      "email": "kamicane@gmail.com"
+    }
+  ],
+  "license": "MIT",
+  "npmName": "primish",
+  "npmFileMap": [
+    {
+      "basePath": "/",
+      "files": [
+        "primish-min.js"
+      ]
+    }
+  ]
 }

--- a/ajax/libs/queue-async/package.json
+++ b/ajax/libs/queue-async/package.json
@@ -23,5 +23,15 @@
   },
   "scripts": {
     "test": "node_modules/.bin/vows; echo"
-  }
+  },
+  "npmName": "queue-async",
+  "npmFileMap": [
+    {
+      "basePath": "/",
+      "files": [
+        "queue.min.js",
+        "queue.js"
+      ]
+    }
+  ]
 }

--- a/ajax/libs/qwery/package.json
+++ b/ajax/libs/qwery/package.json
@@ -1,25 +1,40 @@
 {
-    "name": "qwery"
-  , "description": "blazing fast CSS3 query selector engine"
-  , "version": "3.4.1"
-  , "homepage": "https://github.com/ded/qwery"
-  , "author": "Dustin Diaz <dustin@dustindiaz.com> (http://dustindiaz.com)"
-  , "contributors": [
-        "Jacob Thornton <> (https://github.com/fat)"
-      , "Rod Vagg <> (https://github.com/rvagg)"
-      , "Andrew McCollum <> (https://github.com/amccollum)"
-    ]
-  , "filename": "qwery.js"
-  , "keywords": ["ender", "query", "css", "selector engine"]
-  , "ender": "./src/ender.js"
-  , "repository": {
-        "type": "git"
-      , "url": "https://github.com/ded/qwery.git"
+  "name": "qwery",
+  "description": "blazing fast CSS3 query selector engine",
+  "version": "3.4.1",
+  "homepage": "https://github.com/ded/qwery",
+  "author": "Dustin Diaz <dustin@dustindiaz.com> (http://dustindiaz.com)",
+  "contributors": [
+    "Jacob Thornton <> (https://github.com/fat)",
+    "Rod Vagg <> (https://github.com/rvagg)",
+    "Andrew McCollum <> (https://github.com/amccollum)"
+  ],
+  "filename": "qwery.js",
+  "keywords": [
+    "ender",
+    "query",
+    "css",
+    "selector engine"
+  ],
+  "ender": "./src/ender.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ded/qwery.git"
+  },
+  "devDependencies": {
+    "sink-test": ">= 1.0.1",
+    "serve": "*",
+    "smoosh": "0.4.0",
+    "phantomjs": "0.2.3"
+  },
+  "npmName": "qwery",
+  "npmFileMap": [
+    {
+      "basePath": "/",
+      "files": [
+        "qwery.js",
+        "qwery.min.js"
+      ]
     }
-  , "devDependencies": {
-        "sink-test": ">= 1.0.1"
-      , "serve": "*"
-      , "smoosh": "0.4.0"
-      , "phantomjs": "0.2.3"
-    }
+  ]
 }

--- a/ajax/libs/reqwest/package.json
+++ b/ajax/libs/reqwest/package.json
@@ -1,24 +1,42 @@
 {
-    "name": "reqwest"
-  , "description": "A wrapper for asynchronous http requests"
-  , "version": "1.1.0"
-  , "homepage": "https://github.com/ded/reqwest"
-  , "author": "Dustin Diaz <dustin@dustindiaz.com> (http://dustindiaz.com)"
-  , "filename": "reqwest.js"
-  , "keywords": ["ender", "ajax", "xhr", "connection", "web 2.0", "async", "sync"]
-  , "ender": "./src/ender.js"
-  , "repository": {
-        "type": "git"
-      , "url": "https://github.com/ded/reqwest.git"
+  "name": "reqwest",
+  "description": "A wrapper for asynchronous http requests",
+  "version": "1.1.0",
+  "homepage": "https://github.com/ded/reqwest",
+  "author": "Dustin Diaz <dustin@dustindiaz.com> (http://dustindiaz.com)",
+  "filename": "reqwest.js",
+  "keywords": [
+    "ender",
+    "ajax",
+    "xhr",
+    "connection",
+    "web 2.0",
+    "async",
+    "sync"
+  ],
+  "ender": "./src/ender.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ded/reqwest.git"
+  },
+  "devDependencies": {
+    "connect": "1.8.x",
+    "mime": "1.x.x",
+    "sink-test": ">=0.1.2",
+    "dispatch": "0.x.x",
+    "valentine": ">=1.4.7",
+    "smoosh": "0.4.0",
+    "delayed-stream": "0.0.5",
+    "bump": "0.2.3"
+  },
+  "npmName": "reqwest",
+  "npmFileMap": [
+    {
+      "basePath": "/",
+      "files": [
+        "reqwest.js",
+        "reqwest.min.js"
+      ]
     }
-  , "devDependencies": {
-        "connect": "1.8.x"
-      , "mime": "1.x.x"
-      , "sink-test": ">=0.1.2"
-      , "dispatch": "0.x.x"
-      , "valentine": ">=1.4.7"
-      , "smoosh": "0.4.0"
-      , "delayed-stream": "0.0.5"
-      , "bump": "0.2.3"
-    }
+  ]
 }

--- a/ajax/libs/reveal.js/package.json
+++ b/ajax/libs/reveal.js/package.json
@@ -1,23 +1,70 @@
 {
-    "name": "reveal.js",
-    "filename": "js/reveal.min.js",
-    "version": "2.6.2",
-    "description": "A framework for easily creating beautiful presentations using HTML",
-    "homepage": "http://lab.hakim.se/reveal-js/",
-    "keywords": [
-       "presentations",
-       "slides"
-   ],
-   "maintainers": [
-       {
-           "name": "Hakim El Hattab",
-           "web": "http://hakim.se/"
-       }
-   ],
-   "repositories": [
-       {
-           "type": "git",
-           "url": "https://github.com/hakimel/reveal.js.git"
-       }
-   ]
+  "name": "reveal.js",
+  "filename": "js/reveal.min.js",
+  "version": "2.6.2",
+  "description": "A framework for easily creating beautiful presentations using HTML",
+  "homepage": "http://lab.hakim.se/reveal-js/",
+  "keywords": [
+    "presentations",
+    "slides"
+  ],
+  "maintainers": [
+    {
+      "name": "Hakim El Hattab",
+      "web": "http://hakim.se/"
+    }
+  ],
+  "repositories": [
+    {
+      "type": "git",
+      "url": "https://github.com/hakimel/reveal.js.git"
+    }
+  ],
+  "npmName": "reveal.js",
+  "npmFileMap": [
+    {
+      "basePath": "/",
+      "files": [
+        "css/print/paper.css",
+        "css/print/pdf.css",
+        "css/reveal.css",
+        "css/reveal.min.css",
+        "css/theme/beige.css",
+        "css/theme/blood.css",
+        "css/theme/default.css",
+        "css/theme/moon.css",
+        "css/theme/night.css",
+        "css/theme/serif.css",
+        "css/theme/simple.css",
+        "css/theme/sky.css",
+        "css/theme/solarized.css",
+        "lib/css/zenburn.css",
+        "js/reveal.min.js",
+        "lib/font/league_gothic-webfont.eot",
+        "lib/font/league_gothic-webfont.svg",
+        "lib/font/league_gothic-webfont.ttf",
+        "lib/font/league_gothic-webfont.woff",
+        "js/reveal.js",
+        "lib/js/classList.js",
+        "lib/js/head.min.js",
+        "lib/js/html5shiv.js",
+        "plugin/markdown/markdown.js",
+        "plugin/markdown/marked.js",
+        "plugin/highlight/highlight.js",
+        "plugin/leap/leap.js",
+        "plugin/math/math.js",
+        "plugin/multiplex/client.js",
+        "plugin/multiplex/index.js",
+        "plugin/multiplex/master.js",
+        "plugin/notes-server/client.js",
+        "plugin/notes-server/index.js",
+        "plugin/notes/notes.js",
+        "plugin/postmessage/postmessage.js",
+        "plugin/print-pdf/print-pdf.js",
+        "plugin/remotes/remotes.js",
+        "plugin/search/search.js",
+        "plugin/zoom-js/zoom.js"
+      ]
+    }
+  ]
 }

--- a/ajax/libs/rickshaw/package.json
+++ b/ajax/libs/rickshaw/package.json
@@ -1,26 +1,38 @@
 {
-    "name": "rickshaw",
-    "filename": "rickshaw.min.js",
-    "version": "1.4.6",
-    "description": "JavaScript toolkit for creating interactive real-time graphs",
-    "keywords": [
-        "graphs",
-        "charts",
-        "interactive",
-        "time-series",
-        "svg",
-        "d3",
-        "bars",
-        "lines",
-        "scatterplot"
-    ],
-    "homepage": "http://code.shutterstock.com/rickshaw/",
-    "author": {
-        "name": "David Chester",
-        "email": "david@shutterstock.com"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/shutterstock/rickshaw.git"
+  "name": "rickshaw",
+  "filename": "rickshaw.min.js",
+  "version": "1.4.6",
+  "description": "JavaScript toolkit for creating interactive real-time graphs",
+  "keywords": [
+    "graphs",
+    "charts",
+    "interactive",
+    "time-series",
+    "svg",
+    "d3",
+    "bars",
+    "lines",
+    "scatterplot"
+  ],
+  "homepage": "http://code.shutterstock.com/rickshaw/",
+  "author": {
+    "name": "David Chester",
+    "email": "david@shutterstock.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/shutterstock/rickshaw.git"
+  },
+  "npmName": "rickshaw",
+  "npmFileMap": [
+    {
+      "basePath": "/",
+      "files": [
+        "rickshaw.css",
+        "rickshaw.min.css",
+        "rickshaw.js",
+        "rickshaw.min.js"
+      ]
     }
+  ]
 }

--- a/ajax/libs/sass.js/package.json
+++ b/ajax/libs/sass.js/package.json
@@ -19,5 +19,18 @@
       "type": "git",
       "url": "https://github.com/medialize/sass.js"
     }
+  ],
+  "npmName": "sass.js",
+  "npmFileMap": [
+    {
+      "basePath": "/",
+      "files": [
+        "dist/sass.worker.js",
+        "dist/worker.js",
+        "dist/sass.min.js",
+        "dist/worker.min.js",
+        "dist/sass.js"
+      ]
+    }
   ]
 }

--- a/ajax/libs/shred/package.json
+++ b/ajax/libs/shred/package.json
@@ -1,26 +1,35 @@
 {
-    "name": "shred",
-    "filename": "shred.bundle.min.js",
-    "version": "0.7.12",
-    "description": "Shred is an HTTP client library for browsers and node.js. Shred supports gzip, cookies, https, proxies, and redirects.",
-    "homepage": "https://github.com/automatthew/shred",
-    "keywords": [
-       "http",
-       "xhr",
-       "ajax",
-       "browserify"
-   ],
-   "maintainers": [
-       {
-           "name": "Spire.io",
-           "email": "contact@spire.io",
-           "web": "http://spire.io"
-       }
-   ],
-   "repositories": [
-       {
-           "type": "git",
-           "url": "https://github.com/spire-io/shred"
-       }
-   ]
+  "name": "shred",
+  "filename": "shred.bundle.min.js",
+  "version": "0.7.12",
+  "description": "Shred is an HTTP client library for browsers and node.js. Shred supports gzip, cookies, https, proxies, and redirects.",
+  "homepage": "https://github.com/automatthew/shred",
+  "keywords": [
+    "http",
+    "xhr",
+    "ajax",
+    "browserify"
+  ],
+  "maintainers": [
+    {
+      "name": "Spire.io",
+      "email": "contact@spire.io",
+      "web": "http://spire.io"
+    }
+  ],
+  "repositories": [
+    {
+      "type": "git",
+      "url": "https://github.com/spire-io/shred"
+    }
+  ],
+  "npmName": "shred",
+  "npmFileMap": [
+    {
+      "basePath": "/",
+      "files": [
+        "browser/shred.bundle.min.js"
+      ]
+    }
+  ]
 }

--- a/ajax/libs/speakingurl/package.json
+++ b/ajax/libs/speakingurl/package.json
@@ -1,102 +1,113 @@
 {
-    "name": "speakingurl",
-    "version": "0.8.4",
-    "description": "Generate a slug with a lot of options; create of so called 'static' or 'Clean URL' or 'Pretty URL' or 'nice-looking URL' or 'Speaking URL' or 'user-friendly URL' or 'SEO-friendly URL' from a string.",
-    "homepage": "http://pid.github.io/speakingurl/",
-    "github": "http://github.com/pid/speakingurl",
-    "repository": {
-        "type": "git",
-        "url": "git://github.com:pid/speakingurl.git"
-    },
-    "bugs": "https://github.com/pid/speakingurl/issues",
-    "licenses": [{
-        "type": "BSD",
-        "url": "https://raw.github.com/pid/speakingurl/master/LICENSE"
-    }],
-    "keywords": [
-        "slug",
-        "permalink",
-        "seo",
-        "url",
-        "speakingurl",
-        "speaking url",
-        "nice url",
-        "static url",
-        "transliteration"
-    ],
-    "categories": [
-        "Utilities",
-        "Parsers & Compilers"
-    ],
-    "scripts": {
-        "test": "mocha"
-    },
-    "author": {
-        "name": "Sascha Droste",
-        "email": "pid@posteo.net",
-        "url": "https://twitter.com/SaschaDroste"
-    },
-    "main": "index",
-    "filename": "speakingurl.min.js",
-    "dependencies": {},
-    "devDependencies": {
-        "grunt": "~0.4.2",
-        "mocha": "~1.17.0",
-        "should": "~3.1.0",
-        "grunt-contrib-uglify": "~0.3.2",
-        "grunt-contrib-jshint": "~0.8.0",
-        "grunt-contrib-watch": "~0.5.3",
-        "grunt-release": "~0.6.0",
-        "grunt-bumpup": "~0.5.0",
-        "grunt-text-replace": "~0.3.10",
-        "grunt-jsbeautifier": "~0.2.6"
-    },
-    "testling": {
-        "harness": "mocha",
-        "files": "test/*.js",
-        "browsers": {
-            "ie": [
-                6,
-                7,
-                8,
-                9,
-                10
-            ],
-            "firefox": [
-                19
-            ],
-            "chrome": [
-                25
-            ],
-            "safari": [
-                5.1,
-                6
-            ],
-            "opera": [
-                10,
-                12
-            ]
-        }
-    },
-    "jam": {
-        "dependencies": {},
-        "main": "speakingurl.min.js",
-        "shim": {
-            "deps": [],
-            "exports": [
-                "getSlug",
-                "createSlug"
-            ]
-        },
-        "include": [
-            "speakingurl.min.js",
-            "README.md"
-        ]
-    },
-    "volo": {
-        "url": "//cdnjs.cloudflare.com/ajax/libs/speakingurl/{version}/speakingurl.min.js"
-    },
-    "engines": {
-        "node": ">=0.8.0"
+  "name": "speakingurl",
+  "version": "0.8.4",
+  "description": "Generate a slug with a lot of options; create of so called 'static' or 'Clean URL' or 'Pretty URL' or 'nice-looking URL' or 'Speaking URL' or 'user-friendly URL' or 'SEO-friendly URL' from a string.",
+  "homepage": "http://pid.github.io/speakingurl/",
+  "github": "http://github.com/pid/speakingurl",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com:pid/speakingurl.git"
+  },
+  "bugs": "https://github.com/pid/speakingurl/issues",
+  "licenses": [
+    {
+      "type": "BSD",
+      "url": "https://raw.github.com/pid/speakingurl/master/LICENSE"
     }
+  ],
+  "keywords": [
+    "slug",
+    "permalink",
+    "seo",
+    "url",
+    "speakingurl",
+    "speaking url",
+    "nice url",
+    "static url",
+    "transliteration"
+  ],
+  "categories": [
+    "Utilities",
+    "Parsers & Compilers"
+  ],
+  "scripts": {
+    "test": "mocha"
+  },
+  "author": {
+    "name": "Sascha Droste",
+    "email": "pid@posteo.net",
+    "url": "https://twitter.com/SaschaDroste"
+  },
+  "main": "index",
+  "filename": "speakingurl.min.js",
+  "dependencies": {},
+  "devDependencies": {
+    "grunt": "~0.4.2",
+    "mocha": "~1.17.0",
+    "should": "~3.1.0",
+    "grunt-contrib-uglify": "~0.3.2",
+    "grunt-contrib-jshint": "~0.8.0",
+    "grunt-contrib-watch": "~0.5.3",
+    "grunt-release": "~0.6.0",
+    "grunt-bumpup": "~0.5.0",
+    "grunt-text-replace": "~0.3.10",
+    "grunt-jsbeautifier": "~0.2.6"
+  },
+  "testling": {
+    "harness": "mocha",
+    "files": "test/*.js",
+    "browsers": {
+      "ie": [
+        6,
+        7,
+        8,
+        9,
+        10
+      ],
+      "firefox": [
+        19
+      ],
+      "chrome": [
+        25
+      ],
+      "safari": [
+        5.1,
+        6
+      ],
+      "opera": [
+        10,
+        12
+      ]
+    }
+  },
+  "jam": {
+    "dependencies": {},
+    "main": "speakingurl.min.js",
+    "shim": {
+      "deps": [],
+      "exports": [
+        "getSlug",
+        "createSlug"
+      ]
+    },
+    "include": [
+      "speakingurl.min.js",
+      "README.md"
+    ]
+  },
+  "volo": {
+    "url": "//cdnjs.cloudflare.com/ajax/libs/speakingurl/{version}/speakingurl.min.js"
+  },
+  "engines": {
+    "node": ">=0.8.0"
+  },
+  "npmName": "speakingurl",
+  "npmFileMap": [
+    {
+      "basePath": "/",
+      "files": [
+        "speakingurl.min.js"
+      ]
+    }
+  ]
 }

--- a/ajax/libs/stapes/package.json
+++ b/ajax/libs/stapes/package.json
@@ -1,20 +1,34 @@
 {
-    "name": "stapes",
-    "filename": "stapes.min.js",
-    "author" : "Hay Kranen <hay@bykr.org>",
-    "homepage" : "http://hay.github.com/stapes",
-    "description": "A (really) tiny Javascript MVC microframework.",
-    "keywords": ["mvc", "framework", "lightweight"],
-    "version": "0.8.0",
-    "repository" : {
-        "type" : "git",
-        "url" : "http://github.com/hay/stapes.git"
-    },
-   "maintainers": [
-       {
-           "name": "Hay Kranen",
-           "email": "hay@bykr.org",
-           "web": "http://www.haykranen.nl"
-       }
-   ]
+  "name": "stapes",
+  "filename": "stapes.min.js",
+  "author": "Hay Kranen <hay@bykr.org>",
+  "homepage": "http://hay.github.com/stapes",
+  "description": "A (really) tiny Javascript MVC microframework.",
+  "keywords": [
+    "mvc",
+    "framework",
+    "lightweight"
+  ],
+  "version": "0.8.0",
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/hay/stapes.git"
+  },
+  "maintainers": [
+    {
+      "name": "Hay Kranen",
+      "email": "hay@bykr.org",
+      "web": "http://www.haykranen.nl"
+    }
+  ],
+  "npmName": "stapes",
+  "npmFileMap": [
+    {
+      "basePath": "/",
+      "files": [
+        "stapes.js",
+        "stapes.min.js"
+      ]
+    }
+  ]
 }

--- a/ajax/libs/string_score/package.json
+++ b/ajax/libs/string_score/package.json
@@ -1,28 +1,36 @@
 {
-    "name": "string_score",
-    "filename": "string_score.min.js",
-    "version": "0.1.20",
-    "description": "string_score - JavaScript string ranking library",
-    "homepage": "https://github.com/joshaven/string_score",
-    "keywords": [
-       "search",
-       "string ranking",
-       "algorithms",
-			 "string score"
-   ],
-   "maintainers": [
-       {
-           "name": "Joshaven Potter",
-           "email": "yourtech@gmail.com",
-           "web": "http://www.joshaven.com/string_score/"
-       } 
-   ],
-   "repositories": [
-       {
-           "type": "git",
-           "url": "https://github.com/joshaven/string_score.git" 
-       } 
-   ]
-
+  "name": "string_score",
+  "filename": "string_score.min.js",
+  "version": "0.1.20",
+  "description": "string_score - JavaScript string ranking library",
+  "homepage": "https://github.com/joshaven/string_score",
+  "keywords": [
+    "search",
+    "string ranking",
+    "algorithms",
+    "string score"
+  ],
+  "maintainers": [
+    {
+      "name": "Joshaven Potter",
+      "email": "yourtech@gmail.com",
+      "web": "http://www.joshaven.com/string_score/"
+    }
+  ],
+  "repositories": [
+    {
+      "type": "git",
+      "url": "https://github.com/joshaven/string_score.git"
+    }
+  ],
+  "npmName": "string_score",
+  "npmFileMap": [
+    {
+      "basePath": "/",
+      "files": [
+        "string_score.js",
+        "string_score.min.js"
+      ]
+    }
+  ]
 }
-

--- a/ajax/libs/typeahead.js/package.json
+++ b/ajax/libs/typeahead.js/package.json
@@ -1,23 +1,37 @@
 {
-    "name": "typeahead.js",
-    "filename": "typeahead.bundle.min.js",
-    "version": "0.10.2",
-    "description": "a fast and fully-featured autocomplete library",
-    "homepage": "http://twitter.github.com/typeahead.js/",
-    "keywords": [
-       "twitter",
-       "typeahead",
-       "autocomplete"
-   ],
-   "maintainers": [
-       {
-           "name": "Twitter, Inc."
-       }
-   ],
-   "repositories": [
-       {
-           "type": "git",
-           "url": "https://github.com/twitter/typeahead.js"
-       }
-   ]
+  "name": "typeahead.js",
+  "filename": "typeahead.bundle.min.js",
+  "version": "0.10.2",
+  "description": "a fast and fully-featured autocomplete library",
+  "homepage": "http://twitter.github.com/typeahead.js/",
+  "keywords": [
+    "twitter",
+    "typeahead",
+    "autocomplete"
+  ],
+  "maintainers": [
+    {
+      "name": "Twitter, Inc."
+    }
+  ],
+  "repositories": [
+    {
+      "type": "git",
+      "url": "https://github.com/twitter/typeahead.js"
+    }
+  ],
+  "npmName": "typeahead.js",
+  "npmFileMap": [
+    {
+      "basePath": "/",
+      "files": [
+        "dist/bloodhound.js",
+        "dist/bloodhound.min.js",
+        "dist/typeahead.bundle.min.js",
+        "dist/typeahead.jquery.js",
+        "dist/typeahead.jquery.min.js",
+        "dist/typeahead.bundle.js"
+      ]
+    }
+  ]
 }

--- a/ajax/libs/underscore.string/package.json
+++ b/ajax/libs/underscore.string/package.json
@@ -1,30 +1,38 @@
 {
-    "name": "underscore.string",
-    "filename": "underscore.string.min.js",
-    "version": "2.3.3",
-    "description": "Underscore.string is JavaScript library for comfortable manipulation with strings, extension for Underscore.js inspired by Prototype.js, Right.js, Underscore and beautiful Ruby language.",
-    "homepage": "http://epeli.github.com/underscore.string/",
-    "keywords": [
-       "utility",
-       "string",
-       "underscore"
-   ],
-   "maintainers": [
-       {
-           "name": "Esa-Matti Suuronen",
-           "email": "esa-matti@suuronen.org",
-           "web": "http://esa-matti.suuronen.org"
-
-       },
-       {
-           "name": "Edward Tsech",
-           "email": "edtsech@gmail.com" 
-       } 
-   ],
-   "repositories": [
-       {
-           "type": "git",
-           "url": "https://github.com/epeli/underscore.string" 
-       } 
-   ]
+  "name": "underscore.string",
+  "filename": "underscore.string.min.js",
+  "version": "2.3.3",
+  "description": "Underscore.string is JavaScript library for comfortable manipulation with strings, extension for Underscore.js inspired by Prototype.js, Right.js, Underscore and beautiful Ruby language.",
+  "homepage": "http://epeli.github.com/underscore.string/",
+  "keywords": [
+    "utility",
+    "string",
+    "underscore"
+  ],
+  "maintainers": [
+    {
+      "name": "Esa-Matti Suuronen",
+      "email": "esa-matti@suuronen.org",
+      "web": "http://esa-matti.suuronen.org"
+    },
+    {
+      "name": "Edward Tsech",
+      "email": "edtsech@gmail.com"
+    }
+  ],
+  "repositories": [
+    {
+      "type": "git",
+      "url": "https://github.com/epeli/underscore.string"
+    }
+  ],
+  "npmName": "underscore.string",
+  "npmFileMap": [
+    {
+      "basePath": "/",
+      "files": [
+        "dist/underscore.string.min.js"
+      ]
+    }
+  ]
 }

--- a/ajax/libs/vega/package.json
+++ b/ajax/libs/vega/package.json
@@ -1,24 +1,33 @@
 {
-    "name": "vega",
-    "filename": "vega.min.js",
-    "version": "1.3.3",
-    "description": "Vega is a visualization grammar, a declarative format for creating, saving and sharing visualization designs. ",
-    "homepage": "http://trifacta.github.io/vega/",
-    "keywords": [
-       "vega",
-       "vega.js"
-   ],
-   "maintainers": [
-       {
-           "name": "Trifacta Inc.",
-           "web": "http://trifacta.github.io/vega/"
-       }
-   ],
-   "repositories": [
-       {
-           "type": "git",
-           "url": "https://github.com/trifacta/vega.git"
-       }
-   ]
-
+  "name": "vega",
+  "filename": "vega.min.js",
+  "version": "1.3.3",
+  "description": "Vega is a visualization grammar, a declarative format for creating, saving and sharing visualization designs. ",
+  "homepage": "http://trifacta.github.io/vega/",
+  "keywords": [
+    "vega",
+    "vega.js"
+  ],
+  "maintainers": [
+    {
+      "name": "Trifacta Inc.",
+      "web": "http://trifacta.github.io/vega/"
+    }
+  ],
+  "repositories": [
+    {
+      "type": "git",
+      "url": "https://github.com/trifacta/vega.git"
+    }
+  ],
+  "npmName": "vega",
+  "npmFileMap": [
+    {
+      "basePath": "/",
+      "files": [
+        "vega.js",
+        "vega.min.js"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Updated:   Faker, angular-ui-router, backbone-associations, backbone-react-component, bean, bignumber.js, blueimp-gallery, chroma-js, crossfilter, crossroads, cubism, dc, depot, dropzone, es5-shim, eve.js, font-awesome, jsoneditor, jszip, klass, knockback, leapjs, minitranslate, moment-timezone, primish, queue-async, qwery, reqwest, reveal.js, rickshaw, sass.js, shred, speakingurl, stapes, string_score, typeahead.js, underscore.string, vega

They were verified as fully matching contents of cdnjs in npm version and individual files were compared with md5 to show no differences.

package.json contents were beautified as well as a side effect of the script

If you want individual pull requests, I can also do that for bitcoins ;)
