### PR TITLE
fix constant messages about "updating 22 libs" and some minor bugs

### DIFF
--- a/auto-update.js
+++ b/auto-update.js
@@ -6,8 +6,7 @@ var Hipchat = require('node-hipchat'),
     _ = require('lodash'),
     request = require("superagent"),
     async = require("async"),
-    tarball = require('tarball-extract'),
-    mkdirp = require('mkdirp');
+    tarball = require('tarball-extract')
 
 var HC = new Hipchat(process.env.HIPCHAT);
 var hipchat = {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "fs-extra": "~0.8",
     "glob": "~3.2",
     "lodash": "~2.4",
-    "mkdirp": "~0.3",
     "rss": "~0.3",
     "superagent": "~0.17",
     "tarball-extract": "~0.0",


### PR DESCRIPTION
Fix bug where sometimes the extracted pkg dir was not called 'package' so that version would not be updated (this appears to happen some of the time, so the package would eventually get extracted into the expected dir)

removed parallel extraction of 5 libs at the time because sometimes the tar wouldn't get extracted at all, I suspect its a bug in the tar lib.

added a bit more logging and better error checking
