### PR TITLE
Added file size for each file during package list generation.

### DIFF
--- a/build/packages.json.js
+++ b/build/packages.json.js
@@ -90,7 +90,11 @@ glob("ajax/libs/**/package.json", function (error, matches) {
       temp.version = version.replace(/^.+\//, "");
       temp.files = glob.sync(version + "/**/*.*");
       for (var i = 0; i < temp.files.length; i++){
-        temp.files[i] = temp.files[i].replace(version + "/", "");
+        var filespec = temp.files[i];
+        temp.files[i] = {
+          name: filespec.replace(version + "/", ""),
+          size: Math.round(fs.statSync(filespec).size / 1024)
+        };
       }
       package.assets.push(temp);
     });


### PR DESCRIPTION
This adds file size, in kilobytes, for each file in each package. This pull should be merged in concert with the appropriate change in new_website to display the file size on the front-end.

This change helps determine which asset to use when multiple versions are available with different compression options.
