### PR TITLE
Removed bugs from package.json schemata.

### DIFF
--- a/test/schemata/npm-package.json
+++ b/test/schemata/npm-package.json
@@ -7,7 +7,7 @@
             "type": "string",
             "required": true,
             "description": "This makes the correct path on the cdn."
-            },        
+            },
         "name": {
             "type": "string",
             "required": true,
@@ -29,9 +29,6 @@
         "homepage": {
             "type": "string",
             "format": "url"
-            },
-        "bugs": {
-            "type": "string"
             },
         "dependencies": {
             "type": "object",


### PR DESCRIPTION
Several pull requests have been failing the build due to a difference in formatting `bugs`. This had it validating as a string however npm docs show it to be an array (https://www.npmjs.org/doc/files/package.json.html#bugs). As `bugs` wasn't required and I couldn't see cdnjs using it anywhere I thought this would help ease some of the builds failing just because of it.
