### PR TITLE
npm for mo

### DIFF
--- a/ajax/libs/mo/package.json
+++ b/ajax/libs/mo/package.json
@@ -21,5 +21,25 @@
         "AMD",
         "oz",
         "ozjs"
-    ]
+    ],
+    "npmName": "mo",
+    "npmFileMap": [{
+        "basePath": "/",
+        "files": [
+            "browsers.js",
+            "console.js",
+            "cookie.js",
+            "domready.js",
+            "easing.js",
+            "key.js",
+            "lang.js",
+            "mainloop.js",
+            "network.js",
+            "template.js",
+            "easing/*.js",
+            "lang/*.js",
+            "network/*.js",
+            "template/*.js"
+        ]
+    }]
 }


### PR DESCRIPTION
@petecooper the version of the library was quite out dated but the npm package does not contain minified files so I am not sure if we should npm'ise it at all. 

Do you think we should minify files automatically if they are not present?
