### PR TITLE
Update package.json for broken lib link

### DIFF
--- a/ajax/libs/p5.js/package.json
+++ b/ajax/libs/p5.js/package.json
@@ -1,6 +1,16 @@
 {
   "name": "p5.js",
   "filename": "p5.min.js",
+  "npmName": "p5",
+  "npmFileMap": [
+   {
+      "basePath": "/lib/",
+      "files": [
+        "p5.min.js",
+        "p5.js"
+      ]
+    }
+  ],
   "version": "0.2.13",
   "description": "p5.js is a JavaScript client-side library for creating graphic and interactive experiences, using canvas and HTML5, based on the core principles of Processing.",
   "homepage": "http://p5js.org",


### PR DESCRIPTION
Realized we moved the library file but forgot to update the package. All is correct with npm now, adding the link back in here. Sorry about that!
