### PR TITLE
Add PouchDB with auto-updating

### DIFF
--- a/ajax/libs/pouchdb/package.json
+++ b/ajax/libs/pouchdb/package.json
@@ -1,6 +1,10 @@
 {
   "name": "pouchdb",
   "npmName": "pouchdb",
+  "npmFileMap": [{
+    "basePath": "/dist/",
+    "files": ["pouchdb.js", "pouchdb.min.js"]
+  }],
   "version": "2.2.3",
   "filename": "pouchdb.min.js",
   "description": "PouchDB is a pocket-sized database.",


### PR DESCRIPTION
As of version 3.0.1, PouchDB should support auto-updating, since the `dist/` files are in npm.
