### PR TITLE
Added auto update for picturefill

### DIFF
--- a/ajax/libs/picturefill/package.json
+++ b/ajax/libs/picturefill/package.json
@@ -28,5 +28,13 @@
     "repositories": [{
         "type": "git",
         "url": "git://github.com/scottjehl/picturefill.git"
-    }]
+    }],
+    "autoupdate": {
+        "source": "git",
+        "target": "https://github.com/scottjehl/picturefill.git",
+        "basePath": "dist/",
+        "files": [
+            "*"
+        ]
+    }
 }


### PR DESCRIPTION
This should hopefully add auto-updating for Picturefill ([https://github.com/scottjehl/picturefill](https://github.com/scottjehl/picturefill))

Version 2.1.0 was released over a month ago, will this be picked up automatically?
