### PR TITLE
Added npm and git autoupdates for slick-carousel

### DIFF
--- a/ajax/libs/slick-carousel/package.json
+++ b/ajax/libs/slick-carousel/package.json
@@ -21,10 +21,7 @@
         {
             "basePath": "/slick/fonts/",
             "files": [
-                "slick.eot",
-                "slick.svg",
-                "slick.ttf",
-                "slick.woff"
+                "slick.*"
             ]
         }
     ],


### PR DESCRIPTION
Not sure where the npm and git transitions are, or whether git autoupdate is ready, so I've attached two commits below for the slick-carousel library. The first adds npm autoupdate to the package.json, and the second contains git autoupdate details that will need to merge with (overwrite?) the package.json for this library. See `package-gitautoupdate.json`.

Question, since this library ships with various carousel assets, will the autoupdate work if reduced to `slick.*` in the fonts dir? Please quickly scan the filepaths and let me know if I've written anything incorrectly or inefficiently!

Cheers
