### PR TITLE
TinyColor: prepare for npm autoupdate

### DIFF
--- a/ajax/libs/tinycolor/package.json
+++ b/ajax/libs/tinycolor/package.json
@@ -1,5 +1,14 @@
 {
     "name": "tinycolor",
+    "npmName": "tinycolor2",
+    "npmFileMap": [
+      {
+        "basePath": "",
+        "files": [
+          "tinycolor.js"
+        ]
+      }
+    ],
     "filename": "tinycolor.js",
     "version": "1.0.0",
     "description": "Fast, small color manipulation and conversion for JavaScript",
@@ -21,13 +30,5 @@
    "repository": {
 	"type": "git",
         "url": "https://github.com/bgrins/TinyColor"
-   },
-   "autoupdate": {
-      "source": "git",
-      "target": "git://github.com/bgrins/TinyColor.git",
-      "basePath": "",
-      "files": [
-          "tinycolor.js"
-      ]
    }
 }


### PR DESCRIPTION
Update [TinyColor](https://github.com/bgrins/TinyColor) with npm autoupdate support. Only question I have: It's published on npm as [tinycolor2](https://www.npmjs.org/package/tinycolor2). What do I need to change to reflect that?
