### PR TITLE
Add auto-update for coffee-script

### DIFF
--- a/ajax/libs/coffee-script/package.json
+++ b/ajax/libs/coffee-script/package.json
@@ -25,13 +25,13 @@
            "url": "https://github.com/jashkenas/coffee-script.git"
        }
    ],
-+   "npmName": "coffee-script",
-+   "npmFileMap": [
+   "npmName": "coffee-script",
+   "npmFileMap": [
       {
-+       "basePath": "/lib/coffee-script/",
-+       "files": [
-+         "coffee-script.js"
-+       ]
-+     }
-    ]
+         "basePath": "/lib/coffee-script/",
+         "files": [
+            "coffee-script.js"
+         ]
+      }
+   ]
 }


### PR DESCRIPTION
The current release of [coffee-script](https://www.npmjs.org/package/coffee-script) is 1.8.0, so add auto-update configuration.
