### PR TITLE
Added autoupdate info for sbt library

### DIFF
--- a/ajax/libs/sbt/package.json
+++ b/ajax/libs/sbt/package.json
@@ -13,6 +13,17 @@
     "type": "git",
     "url": "https://github.com/OpenNTF/SocialSDK.git"
   },
+  "autoupdate": {
+    "source": "git",
+    "target": "git://github.com/OpenNTF/SocialSDK.git",
+    "basePath": "assembly/cdnjs",
+    "files": [
+      "sbt-core-dojo-amd.js",
+      "sbt-core-dojo-amd.js.uncompressed.js",
+      "sbt-extra-controls-dojo-amd.js",
+      "sbt-extra-controls-dojo-amd.js.uncompressed.js"
+    ]
+  },
   "maintainers":
   [
     {


### PR DESCRIPTION
added autoupdate section mapped to newly created path on the SocialSDK repository, as specified in #3638 
