### PR TITLE
Add angular-ui-date v0.0.6

### DIFF
--- a/ajax/libs/angular-ui-date/0.0.6/date.js
+++ b/ajax/libs/angular-ui-date/0.0.6/date.js
@@ -1,0 +1,138 @@
+/*global angular */
+/*
+ jQuery UI Datepicker plugin wrapper
+
+ @note If ≤ IE8 make sure you have a polyfill for Date.toISOString()
+ @param [ui-date] {object} Options to pass to $.fn.datepicker() merged onto uiDateConfig
+ */
+
+angular.module('ui.date', [])
+
+.constant('uiDateConfig', {})
+
+.directive('uiDate', ['uiDateConfig', 'uiDateConverter', function (uiDateConfig, uiDateConverter) {
+  'use strict';
+  var options;
+  options = {};
+  angular.extend(options, uiDateConfig);
+  return {
+    require:'?ngModel',
+    link:function (scope, element, attrs, controller) {
+      var getOptions = function () {
+        return angular.extend({}, uiDateConfig, scope.$eval(attrs.uiDate));
+      };
+      var initDateWidget = function () {
+        var showing = false;
+        var opts = getOptions();
+
+        // If we have a controller (i.e. ngModelController) then wire it up
+        if (controller) {
+
+          // Set the view value in a $apply block when users selects
+          // (calling directive user's function too if provided)
+          var _onSelect = opts.onSelect || angular.noop;
+          opts.onSelect = function (value, picker) {
+            scope.$apply(function() {
+              showing = true;
+              controller.$setViewValue(element.datepicker("getDate"));
+              _onSelect(value, picker);
+              //element.blur();
+            });
+          };
+          opts.beforeShow = function() {
+            showing = true;
+          };
+          opts.onClose = function(value, picker) {
+            showing = false;
+          };
+          element.off('blur.datepicker').on('blur.datepicker', function() {
+            if ( !showing ) {
+              scope.$apply(function() {
+                element.datepicker("setDate", element.datepicker("getDate"));
+                controller.$setViewValue(element.datepicker("getDate"));
+              });
+            }
+          });
+
+          // Update the date picker when the model changes
+          controller.$render = function () {
+            var date = controller.$modelValue;
+            if ( angular.isDefined(date) && date !== null && !angular.isDate(date) ) {
+                if ( angular.isString(controller.$modelValue) ) {
+                    date = uiDateConverter.stringToDate(attrs.uiDateFormat, controller.$modelValue);
+                } else {
+                    throw new Error('ng-Model value must be a Date, or a String object with a date formatter - currently it is a ' + typeof date + ' - use ui-date-format to convert it from a string');
+                }
+            }
+            element.datepicker("setDate", date);
+          };
+        }
+        // If we don't destroy the old one it doesn't update properly when the config changes
+        element.datepicker('destroy');
+        // Create the new datepicker widget
+        element.datepicker(opts);
+        if ( controller ) {
+          // Force a render to override whatever is in the input text box
+          controller.$render();
+        }
+      };
+      // Watch for changes to the directives options
+      scope.$watch(getOptions, initDateWidget, true);
+    }
+  };
+}
+])
+.factory('uiDateConverter', ['uiDateFormatConfig', function(uiDateFormatConfig){
+
+    function dateToString(dateFormat, value){
+        dateFormat = dateFormat || uiDateFormatConfig;
+        if (value) {
+            if (dateFormat) {
+                return jQuery.datepicker.formatDate(dateFormat, value);
+            }
+            return value.toISOString();
+        } else {
+            return null;
+        }
+    }
+
+    function stringToDate(dateFormat, value) {
+        dateFormat = dateFormat || uiDateFormatConfig;
+        if ( angular.isString(value) ) {
+            if (dateFormat) {
+                return jQuery.datepicker.parseDate(dateFormat, value);
+            }
+
+            var isoDate = new Date(value);
+            return isNaN(isoDate.getTime()) ? null : isoDate;
+        }
+        return null;
+    }
+
+    return {
+        stringToDate: stringToDate,
+        dateToString: dateToString
+    };
+
+}])
+.constant('uiDateFormatConfig', '')
+.directive('uiDateFormat', ['uiDateConverter', function(uiDateConverter) {
+  var directive = {
+    require:'ngModel',
+    link: function(scope, element, attrs, modelCtrl) {
+        var dateFormat = attrs.uiDateFormat;
+
+        // Use the datepicker with the attribute value as the dateFormat string to convert to and from a string
+        modelCtrl.$formatters.unshift(function(value) {
+            return uiDateConverter.stringToDate(dateFormat, value);
+        });
+
+        modelCtrl.$parsers.push(function(value){
+            return uiDateConverter.dateToString(dateFormat, value);
+        });
+
+    }
+  };
+
+  return directive;
+}]);

--- a/ajax/libs/angular-ui-date/package.json
+++ b/ajax/libs/angular-ui-date/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "angular-ui-date",
+  "version": "0.0.6",
+  "description": "This directive allows you to add a date-picker to your form elements.",
+  "author": "https://github.com/angular-ui/ui-date/graphs/contributors",
+  "license": "MIT",
+  "homepage": "http://angular-ui.github.com/ui-date",
+  "filename": "date.js",
+  "dependencies": {},
+  "devDependencies": {
+    "grunt": "~0.4.1",
+    "grunt-contrib-jshint": "~0.2.0",
+    "grunt-karma": "~0.4.3",
+    "grunt-conventional-changelog": "~1.0.0"
+  },
+  "scripts": {},
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/angular-ui/ui-date.git"
+  }
+}


### PR DESCRIPTION
This is another component of the angular-ui umbrella. This component builds a date picker using angular directives.

-- This package.json is copy/paste from the ui-date repo. The dependencies seem to be missing. This library depends on jquery, jquery-ui, angular, and a polyfill for Date.toISOString for IE<=8. Should I send a note upstream for that?
