### PR TITLE
Update npmFileMap to the new built package for JsSIP

### DIFF
--- a/ajax/libs/jssip/package.json
+++ b/ajax/libs/jssip/package.json
@@ -6,12 +6,12 @@
     {
       "basePath": "/builds/",
       "files": [
-        "*.min.js"
+        "jssip.js"
       ]
     }
   ],
   "version": "0.5.0",
-  "filename": "jssip.min.js",
+  "filename": "jssip.js",
   "homepage": "http://jssip.net",
   "keywords": [
     "SIP"


### PR DESCRIPTION
JsSIP now builds a package file that does not contain the version number. This pull request should pick up the new versions correctly.
Note however that the new built package will be called "jssip.js" and not "jssip.min.js". I hope this is not an issue.

