### PR TITLE
[author] Updated jplayer cdn to use npm

### DIFF
--- a/ajax/libs/jplayer/package.json
+++ b/ajax/libs/jplayer/package.json
@@ -30,5 +30,12 @@
       "type": "MIT",
       "url": "http://www.opensource.org/licenses/MIT"
     }
-  ]
+  ],
+  "npmName": "jplayer",
+  "npmFileMap": [{
+    "basePath": "/dist/",
+    "files": [
+      "**"
+    ]
+  }]
 }


### PR DESCRIPTION
The author of [jPlayer](https://github.com/happyworm/jPlayer) has updated their `dist` build folder to include the built CSS skins. The npm update has been enabled for [npm install jplayer](https://www.npmjs.com/package/jplayer) package. `npm test` has passed and rebased to latest.
