### PR TITLE
Add InstantClick namespace

### DIFF
--- a/ajax/libs/instantclick/package.json
+++ b/ajax/libs/instantclick/package.json
@@ -4,6 +4,7 @@
     "version": "3.0.1",
     "description": "A Javascript library that preloads pages making use of pjax.",
     "homepage": "instantclick.io",
+    "namespace": "InstantClick",
     "keywords": [
        "ajax",
        "preload",


### PR DESCRIPTION
Adds the namespace field to InstantClick's package.json, following [Libscore's "Help Wanted: Assign libraries to their official pages"](https://github.com/julianshapiro/libscore#help-wanted-assign-libraries-to-their-official-pages)
