### PR TITLE
update aegis library to fix autoupdate paths

### DIFF
--- a/ajax/libs/aegis/package.json
+++ b/ajax/libs/aegis/package.json
@@ -36,10 +36,10 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/playlyfe/aegis.git",
-    "basePath": "/dist/",
+    "basePath": ".",
     "files": [
-      "aegis.css",
-      "aegis.min.css",
+      "dist/aegis.css",
+      "dist/aegis.min.css",
       "fonts/Lyfeicons.woff",
       "fonts/Lyfeicons.ttf",
       "fonts/Lyfeicons.svg",


### PR DESCRIPTION
I had made a mistake in the earlier package.json with the `basePath` configuration. This fixes that.