### PR TITLE
[author] update textAngular to v1.3.0 format

### DIFF
--- a/ajax/libs/textAngular/package.json
+++ b/ajax/libs/textAngular/package.json
@@ -26,11 +26,8 @@
     "target": "git://github.com/fraywing/textAngular.git",
     "basePath": "",
     "files": [
-      "dist/textAngular.min.js",
-      "dist/textAngular-sanitize.min.js",
-      "src/textAngular-sanitize.js",
-      "src/textAngularSetup.js",
-      "src/textAngular.js"
+      "src/*",
+      "dist/*"
     ]
   }
 }


### PR DESCRIPTION
Change the include paths to include all the new paths in the v1.3.0 full and pre-releases.