### PR TITLE
change description for l20n package

### DIFF
--- a/ajax/libs/l20n/package.json
+++ b/ajax/libs/l20n/package.json
@@ -2,7 +2,7 @@
   "name": "l20n",
   "filename": "l20n.min.js",
   "version": "1.0.2",
-  "description": "A localization library from Firefox OS",
+  "description": "A client side localization library from Mozilla",
   "keywords": [
     "localization",
     "l10n"


### PR DESCRIPTION
as discussed in https://bugzilla.mozilla.org/show_bug.cgi?id=1129965#c3

We prefer to change the package statement as "A client side localization library from Mozilla".