### PR TITLE
Fixed backbone.js's package.json to be able to fetch its popularity

### DIFF
--- a/ajax/libs/backbone.js/package.json
+++ b/ajax/libs/backbone.js/package.json
@@ -3,7 +3,7 @@
   "filename": "backbone-min.js",
   "version": "1.1.2",
   "description": "Backbone supplies structure to JavaScript-heavy applications by providing models with key-value binding and custom events, collections with a rich API of enumerable functions, views with declarative event handling, and connects it all to your existing application over a RESTful JSON interface.",
-  "homepage": "http://documentcloud.github.com/backbone/",
+  "homepage": "http://backbonejs.org/",
   "keywords": [
     "collections",
     "models",
@@ -21,7 +21,7 @@
   "repositories": [
     {
       "type": "git",
-      "url": "https://github.com/documentcloud/backbone"
+      "url": "https://github.com/jashkenas/backbone.git"
     }
   ],
   "npmName": "backbone",


### PR DESCRIPTION
Fixed backbone.js's package.json to be able to fetch its popularity from GitHub while indexing. Should fix #4368