### PR TITLE
Updating ekko-lightbox package.json

### DIFF
--- a/ajax/libs/ekko-lightbox/package.json
+++ b/ajax/libs/ekko-lightbox/package.json
@@ -2,26 +2,45 @@
   "name": "ekko-lightbox",
   "version": "3.0.3a",
   "filename": "ekko-lightbox.min.js",
-  "description": "A lightbox gallery plugin for Bootstrap 3 based on the modal plugin.",
-  "homepage": "http://ashleydw.github.io/lightbox/",
-  "author": {
-    "name": "ashleydw",
-    "email": "hello@ashleyd.ws",
-    "url": "http://ashleyd.ws/"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/ashleydw/lightbox/"
-  },
-  "licenses": [
-    {
-      "type": "GNU GENERAL PUBLIC LICENSE",
-      "url": "http://www.gnu.org/licenses/gpl-2.0.html"
-    }
-  ],
-  "keywords": [
+  "description":"A lightbox gallery plugin for Bootstrap 3 based on the modal plugin",
+  "keywords":[
     "lightbox",
-    "bootstrap3",
-    "bootstrap"
+    "gallery",
+    "bootstrap",
+    "jquery",
+    "modal"
+  ],
+  "homepage":"https://github.com/ashleydw/lightbox",
+  "author":"ashleydw <hello@ashleyd.ws>",
+  "main":"dist/ekko-lightbox.min.js",
+  "style":"dist/ekko-lightbox.css",
+  "less":"ekko-lightbox.less",
+  "repository":{
+    "type":"git",
+    "url":"https://github.com/ashleydw/lightbox.git"
+  },
+  "bugs":{
+    "url":"https://github.com/ashleydw/lightbox/issues"
+  },
+  "license":{
+    "type":"GNU GENERAL PUBLIC LICENSE",
+    "url":"https://github.com/ashleydw/lightbox/blob/master/LICENSE.txt"
+  },
+  "devDependencies":{
+    "grunt":"^0.4.5",
+    "grunt-banner":"~0.2.0",
+    "grunt-contrib-coffee":"~0.8.0",
+    "grunt-contrib-uglify":"~0.2.2",
+    "grunt-contrib-watch":"~0.5.1",
+    "grunt-recess":"~0.3.3"
+  },
+  "npmName":"ekko-lightbox",
+  "npmFileMap":[
+    {
+      "basePath":"/dist/",
+      "files":[
+        "*"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
Modified package.json for ekko-lightbox to latest version for autoupdate but left version as 3.0.3a (current is 3.2.2) so that auto-update can do its thing.

This time with correct tab spacing.