### PR TITLE
Updated React Router config to point to new paths

### DIFF
--- a/ajax/libs/react-router/package.json
+++ b/ajax/libs/react-router/package.json
@@ -12,13 +12,12 @@
   ],
   "homepage": "https://github.com/rackt/react-router",
   "bugs": "https://github.com/rackt/react-router/issues",
-  "npmName": "react-router",
-  "npmFileMap": [
-    {
-      "basePath": "/dist/",
-      "files": [
-        "*.js"
-      ]
-    }
-  ]
+  "autoupdate": {
+    "source": "git",
+    "target": "git://github.com/rackt/react-router.git",
+    "basePath": "/build/global",
+    "files": [
+      "*.js"
+    ]
+  }
 }


### PR DESCRIPTION
The paths have changed from `/dist` to `/build/global` due to building
several targets for the 0.12 and 0.13 versions. This has prevented the
builds from entering the CDNJS repo