### PR TITLE
Remove un-bundled source from trianglify files

### DIFF
--- a/ajax/libs/trianglify/package.json
+++ b/ajax/libs/trianglify/package.json
@@ -6,20 +6,11 @@
   "npmName": "trianglify",
   "npmFileMap": [
     {
-      "basePath": "lib",
-      "files": [
-        "trianglify.js"
-      ]
-    },
-    {
       "basePath": "dist",
       "files": [
         "trianglify.min.js"
       ]
     }
-  ],
-  "files": [
-    "angular-image-spinner.min.js"
   ],
   "homepage": "https://github.com/qrohlf/trianglify",
   "author": {


### PR DESCRIPTION
As of v0.2.0 I'm no longer providing non-minified builds of Trianglify.

This commit also removes a stray file that isn't a part of the repo.