### PR TITLE
Make repositories field in package.json be consistently a list

### DIFF
--- a/ajax/libs/blueimp-file-upload/package.json
+++ b/ajax/libs/blueimp-file-upload/package.json
@@ -36,10 +36,10 @@
       "url": "https://blueimp.net"
     }
   ],
-  "repositories": {
+  "repositories": [{
     "type": "git",
     "url": "git://github.com/blueimp/jQuery-File-Upload.git"
-  },
+  }],
   "licenses": [
     {
       "type": "MIT",

--- a/ajax/libs/fluidbox/package.json
+++ b/ajax/libs/fluidbox/package.json
@@ -18,10 +18,10 @@
       "homagepage": "http://terrymun.com"
     }
   ],
-  "repositories": {
+  "repositories": [{
     "type": "git",
     "url": "https://github.com/terrymun/Fluidbox/"
-  },
+  }],
   "main": "jquery.fluidbox.js",
   "keywords": [
     "fluidbox",

--- a/ajax/libs/list.js/package.json
+++ b/ajax/libs/list.js/package.json
@@ -22,10 +22,10 @@
     "html",
     "ui"
   ],
-  "repositories": {
+  "repositories": [{
     "type": "git",
     "url": "git://github.com/javve/list.js.git"
-  },
+  }],
   "license": "MIT",
   "maintainers": [
     {

--- a/ajax/libs/list.pagination.js/package.json
+++ b/ajax/libs/list.pagination.js/package.json
@@ -12,10 +12,10 @@
     "html",
     "ui"
   ],
-  "repositories": {
+  "repositories": [{
     "type": "git",
     "url": "git://github.com/javve/list.pagination.js.git"
-  },
+  }],
   "license": "MIT",
   "maintainers": [
     {

--- a/ajax/libs/min.js/package.json
+++ b/ajax/libs/min.js/package.json
@@ -9,10 +9,10 @@
       "web": "http://github.com/remy"
     }
   ],
-  "repositories": {
+  "repositories": [{
     "type": "git",
     "url": "git://github.com/remy/min.js.git"
-  },
+  }],
   "license": "MIT",
   "keywords": [
     "min",

--- a/ajax/libs/qtip2/package.json
+++ b/ajax/libs/qtip2/package.json
@@ -26,9 +26,9 @@
     "email": "craig@craigsworks.com",
     "web": "http://craigsworks.com"
   },
-  "repositories": {
+  "repositories": [{
     "type": "git",
     "url": "https://github.com/Craga89/qTip2.git"
-  },
+  }],
   "bugs": "https://github.com/Craga89/qTip2/issues"
 }

--- a/ajax/libs/reactive-coffee/package.json
+++ b/ajax/libs/reactive-coffee/package.json
@@ -21,9 +21,10 @@
       "web": "http://yz.mit.edu"
     }
   ],
-  "repositories": [
-    "https://github.com/yang/reactive-coffee"
-  ],
+  "repositories": [{
+    "type": "git",
+    "url": "https://github.com/yang/reactive-coffee"
+  }],
   "dependencies": {
     "underscore": ">=1.4.4",
     "jquery": ">=1.7.0"


### PR DESCRIPTION
Most other package.json's seem to have repositories be a list with dicts in them,
and the name being 'repositories' also makes sense with it being a list.