### PR TITLE
Improved package.json autoupdate field

### DIFF
--- a/ajax/libs/document-register-element/package.json
+++ b/ajax/libs/document-register-element/package.json
@@ -1,6 +1,6 @@
 {
   "name": "document-register-element",
-  "version": "0.3.3",
+  "version": "0.3.0",
   "description": "A stand-alone working lightweight version of the W3C Custom Elements specification",
   "homepage": "https://github.com/WebReflection/document-register-element",
   "keywords": [

--- a/ajax/libs/document-register-element/package.json
+++ b/ajax/libs/document-register-element/package.json
@@ -1,6 +1,6 @@
 {
   "name": "document-register-element",
-  "version": "0.3.0",
+  "version": "0.3.3",
   "description": "A stand-alone working lightweight version of the W3C Custom Elements specification",
   "homepage": "https://github.com/WebReflection/document-register-element",
   "keywords": [
@@ -29,10 +29,7 @@
     {
       "basePath": "/build/",
       "files": [
-        "dre-ie8-upfront-fix.js",
-        "dre-ie8-upfront-fix.max.js",
-        "document-register-element.js",
-        "document-register-element.max.js"
+        "*.js"
       ]
     }
   ]


### PR DESCRIPTION
There is an extra file that arbitrary ships with this polyfill, it's called `innerHTML.js` and is a helper [necessary in some case](https://github.com/WebReflection/document-register-element/issues/21).

Thanks for the update.