### PR TITLE
[cleaned PR] Improved package.json autoupdate field

### DIFF
--- a/ajax/libs/document-register-element/package.json
+++ b/ajax/libs/document-register-element/package.json
@@ -29,10 +29,7 @@
     {
       "basePath": "/build/",
       "files": [
-        "dre-ie8-upfront-fix.js",
-        "dre-ie8-upfront-fix.max.js",
-        "document-register-element.js",
-        "document-register-element.max.js"
+        "*.js"
       ]
     }
   ]


### PR DESCRIPTION
There is an extra file that arbitrary ships with this polyfill, it's called `innerHTML.js` and is a helper [necessary in some case](https://github.com/WebReflection/document-register-element/issues/21).

Thanks for the update.