### PR TITLE
Include plottable.css in plottable.js

### DIFF
--- a/ajax/libs/plottable.js/package.json
+++ b/ajax/libs/plottable.js/package.json
@@ -13,6 +13,7 @@
     "target": "git://github.com/palantir/plottable.git",
     "basePath": "",
     "files": [
+      "plottable.css",
       "plottable.js",
       "plottable.min.js"
     ]


### PR DESCRIPTION
Adds it to `package.json` (auto-update config) and back-fills past versions

@jtlan and @bluong, please make sure I didn't get anything wrong this time around.