### PR TITLE
Clarify that a trailing blank line is required in package.json

### DIFF
--- a/test/valid-packages-test.js
+++ b/test/valid-packages-test.js
@@ -156,7 +156,7 @@ packages.map(function (pkg) {
         var orig = fs.readFileSync(pkg, 'utf8'),
             correct = JSON.stringify(JSON.parse(orig), null, 2) + '\n';
         assert.ok(orig === correct,
-            pkg_name(pkg) + ": package.json wrong format, correct one should be like this.\n(Should remove the first 2 spaces of each line if you want to copy and paste this example)\n" + correct);
+            pkg_name(pkg) + ": package.json wrong format, correct one should be like this.\n(Remove the first 2 spaces of each line and include blank line at end if you copy and paste this example)\n" + correct +"\n");
     }
 
     package_vows[pname + ": useless fields check"] = function (pkg) {


### PR DESCRIPTION
Attempt to clarify that a trailing new line is part of the package.json format when you receive a formatting error. This caused me a moment of confusion trying to copy and paste the example before examining other working files.