### PR TITLE
add auto-update config & update to a stable version of bootstrap-rtl

### DIFF
--- a/ajax/libs/bootstrap-rtl/package.json
+++ b/ajax/libs/bootstrap-rtl/package.json
@@ -23,5 +23,13 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/morteza/bootstrap-rtl.git"
+  },
+  "autoupdate": {
+    "source": "git",
+    "target": "git://github.com/morteza/bootstrap-rtl.git",
+    "basePath": "dist/",
+    "files": [
+      "css/*"
+    ]
   }
 }

--- a/ajax/libs/bootstrap-rtl/package.json
+++ b/ajax/libs/bootstrap-rtl/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bootstrap-rtl",
   "filename": "css/bootstrap-rtl.min.css",
-  "description": "Right-to-left (RTL) support for Boostrap 3.x. Note: due to a versioning error at source, v3.1.2 is identical to v3.1.1. Info: https://github.com/cdnjs/cdnjs/pull/3259",
+  "description": "Right-to-left (RTL) theme for Twitter Bootstrap 3.x",
   "version": "3.1.2",
   "homepage": "https://github.com/morteza/bootstrap-rtl",
   "author": "Morteza Ansarinia <ansarinia@me.com>",
@@ -17,8 +17,8 @@
     "theme"
   ],
   "license": {
-    "type": "Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International",
-    "url": "http://creativecommons.org/licenses/by-nc-sa/4.0/"
+    "type": "Unlicensed Public Domain",
+    "url": "https://github.com/morteza/bootstrap-rtl/blob/master/UNLICENSE"
   },
   "repository": {
     "type": "git",

--- a/ajax/libs/bootstrap-rtl/package.json
+++ b/ajax/libs/bootstrap-rtl/package.json
@@ -2,7 +2,7 @@
   "name": "bootstrap-rtl",
   "filename": "css/bootstrap-rtl.min.css",
   "description": "Right-to-left (RTL) support for Boostrap 3.x. Note: due to a versioning error at source, v3.1.2 is identical to v3.1.1. Info: https://github.com/cdnjs/cdnjs/pull/3259",
-  "version": "3.2.0-rc2",
+  "version": "3.1.2",
   "homepage": "https://github.com/morteza/bootstrap-rtl",
   "author": "Morteza Ansarinia <ansarinia@me.com>",
   "keywords": [


### PR DESCRIPTION
Hi @maruilian11 , From #5276, I would like to fix bootstrap-rtl to point to a stable version.
repo: https://github.com/morteza/bootstrap-rtl
The latest stable version of bootstrap-rtl is v3.3.4, but cdnjs doesn't have now.
So I add v3.3.4 and update version number to 3.3.4 in package.json.
I also add git auto-update config in package.json.
Would you mind checking this PR for me? Thank you~ :-)
