### PR TITLE
add auto-update config & point to a stable version of markdown.js

### DIFF
--- a/ajax/libs/markdown.js/package.json
+++ b/ajax/libs/markdown.js/package.json
@@ -20,5 +20,14 @@
       "type": "git",
       "url": "https://github.com/evilstreak/markdown-js"
     }
+  ],
+  "npmName": "markdown",
+  "npmFileMap": [
+    {
+      "basePath": "lib/",
+      "files": [
+        "markdown*.js"
+      ]
+    }
   ]
 }

--- a/ajax/libs/markdown.js/package.json
+++ b/ajax/libs/markdown.js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "markdown.js",
   "filename": "markdown.min.js",
-  "version": "0.6.0-beta1",
+  "version": "0.5.0",
   "description": "Yet another Markdown parser, this time for JavaScript. There's a few options that precede this project but they all treat Markdown to HTML conversion as a single step process. You pass Markdown in and get HTML out, end of story.",
   "homepage": "https://github.com/evilstreak/markdown-js/",
   "keywords": [

--- a/ajax/libs/markdown.js/package.json
+++ b/ajax/libs/markdown.js/package.json
@@ -2,12 +2,13 @@
   "name": "markdown.js",
   "filename": "markdown.min.js",
   "version": "0.5.0",
-  "description": "Yet another Markdown parser, this time for JavaScript. There's a few options that precede this project but they all treat Markdown to HTML conversion as a single step process. You pass Markdown in and get HTML out, end of story.",
+  "description": "A sensible Markdown parser for javascript",
   "homepage": "https://github.com/evilstreak/markdown-js/",
   "keywords": [
     "markdown",
     "markdown-js",
-    "markdown.js"
+    "text processing",
+    "ast"
   ],
   "maintainers": [
     {


### PR DESCRIPTION
Hi @LeaYeh , From #5276, I would like to fix markdown.js to point to a stable version.
repo: https://github.com/evilstreak/markdown-js
This lib doesn't have auto-update, so I add npm auto-update config in package.json.
I think you may need to install it from npm for checking the file map.
The latest version on npm is v0.5.0,  but it doesn't provide minified version.
cdnjs has the minified file already, so I only record it in "requiredFile" field.
Would you mind checking this PR for me? Thank you~ :-)