### PR TITLE
Replace npm autoupdate with git autoupdate in angular-bindonce. close 4972.

### DIFF
--- a/ajax/libs/angular-bindonce/package.json
+++ b/ajax/libs/angular-bindonce/package.json
@@ -26,14 +26,12 @@
     "watcher",
     "bindonce"
   ],
-  "npmName": "angular-bindonce",
-  "npmFileMap": [
-    {
-      "basePath": "/",
-      "files": [
-        "bindonce.js",
-        "bindonce.min.js"
-      ]
-    }
-  ]
+  "autoupdate": {
+    "source": "git",
+    "target": "git://github.com/Pasvaz/bindonce.git",
+    "basePath": "",
+    "files": [
+      "bindonce*.js"
+    ]
+  }
 }


### PR DESCRIPTION
@Amomo, I need your help for checking this PR.
The library had released the version 0.3.3 on git, however, the latest version installed from npm autoupdate still in 0.3.1.
In order to the reason, I think it's time to change the npm autoupdate to the git autoupdate for getting the latest version of the library.
Thank you!