### PR TITLE
point to a stable version v0.3.4 of json-mask

### DIFF
--- a/ajax/libs/json-mask/package.json
+++ b/ajax/libs/json-mask/package.json
@@ -1,7 +1,7 @@
 {
   "name": "json-mask",
   "filename": "jsonMask.min.js",
-  "version": "0.1.1-alpha",
+  "version": "0.3.4",
   "description": "Tiny language and engine for selecting specific parts of a JS object, preserving the structure of the original, and hiding the rest.",
   "homepage": "https://github.com/nemtsov/json-mask",
   "keywords": [


### PR DESCRIPTION
@Piicksarn , From #5276, I would like to fix json-mask to point to a stable version.
repo: https://github.com/nemtsov/json-mask
In cdnjs, json-mask has auto-update config, so it is the latest version now.
I only modify the field of version to a stable version `0.3.4`.
Would you mind checking this PR for me? Thank you~ :-)

- [ ] Not found on cdnjs repo : `json-mask`
- [ ] No already exist issue and PR : `#5276`
- [x] Notable popularity
- [x] Project has public repository on famous online hosting platform (or been hosted on npm)
- [x] Has valid tags for each versions (for git auto-update)
- [x] Auto-update setup
- [x] Auto-update target/source is valid.
- [x] Auto-update filemap is correct.