### PR TITLE
point to a stable version v0.4.0 of two.js

### DIFF
--- a/ajax/libs/two.js/package.json
+++ b/ajax/libs/two.js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "two.js",
   "filename": "two.min.js",
-  "version": "0.1.0-alpha",
+  "version": "0.4.0",
   "description": "A two-dimensional drawing api meant for modern browsers.",
   "homepage": "http://jonobr1.github.com/two.js",
   "keywords": [


### PR DESCRIPTION
Hi @maruilian11  , From #5276, I would like to fix two.js to point to a stable version.
repo: https://github.com/jonobr1/two.js
In cdnjs, two.js has auto-update config already, so it is the latest version now.
I only modify the field of version to a stable version `0.4.0`.
Would you mind checking this PR for me? Thank you~ :-)

- [ ] Not found on cdnjs repo : `two.js`
- [ ] No already exist issue and PR : `#5276`
- [x] Notable popularity : `4377` star, `2344` fork
- [x] Project has public repository on famous online hosting platform (or been hosted on npm)
- [x] Has valid tags for each versions (for git auto-update)
- [x] Auto-update setup
- [x] Auto-update target/source is valid.
- [x] Auto-update filemap is correct.