### PR TITLE
add Crafty with git auto-update, close #5361

### DIFF
--- a/ajax/libs/crafty/package.json
+++ b/ajax/libs/crafty/package.json
@@ -28,5 +28,13 @@
       "type": "git",
       "url": "https://github.com/craftyjs/Crafty.git"
     }
-  ]
+  ],
+  "autoupdate": {
+    "source": "git",
+    "target": "git://github.com/craftyjs/Crafty.git",
+    "basePath": "dist",
+    "files": [
+      "**/*"
+    ]
+  }
 }


### PR DESCRIPTION
@Amomo, would you please checking the pr for me?
This pr is for adding git auto-update in exist library.
The lib information is shown below. 
Thank you!

**`git repository url :`** https://github.com/craftyjs/Crafty
`Watch : 130` 
`Star : 1848`
`Fork : 452 `


 - [ ] Not found on cdnjs repo ------**`This PR in not for adding new library`**
 - [x] No already exist issue and PR
 - [x] Notable popularity
 - [x] Project has public repository on famous online hosting platform (or been hosted on npm)
 - [x] Has valid tags for each versions (for git auto-update)
 - [x] Auto-update setup
 - [x] Auto-update target/source is valid.
 - [x] Auto-update filemap is correct.
