### PR TITLE
[new] add domready@1.0.8 with git auto-update, close #5251

### DIFF
--- a/ajax/libs/domready/1.0.8/ready.js
+++ b/ajax/libs/domready/1.0.8/ready.js
@@ -1,0 +1,30 @@
+/*!
+  * domready (c) Dustin Diaz 2014 - License MIT
+  */
+!function (name, definition) {
+
+  if (typeof module != 'undefined') module.exports = definition()
+  else if (typeof define == 'function' && typeof define.amd == 'object') define(definition)
+  else this[name] = definition()
+
+}('domready', function () {
+
+  var fns = [], listener
+    , doc = document
+    , hack = doc.documentElement.doScroll
+    , domContentLoaded = 'DOMContentLoaded'
+    , loaded = (hack ? /^loaded|^c/ : /^loaded|^i|^c/).test(doc.readyState)
+
+
+  if (!loaded)
+  doc.addEventListener(domContentLoaded, listener = function () {
+    doc.removeEventListener(domContentLoaded, listener)
+    loaded = 1
+    while (listener = fns.shift()) listener()
+  })
+
+  return function (fn) {
+    loaded ? setTimeout(fn, 0) : fns.push(fn)
+  }
+
+});

--- a/ajax/libs/domready/1.0.8/ready.min.js
+++ b/ajax/libs/domready/1.0.8/ready.min.js
@@ -1,0 +1,4 @@
+/*!
+  * domready (c) Dustin Diaz 2014 - License MIT
+  */
+!function(e,t){typeof module!="undefined"?module.exports=t():typeof define=="function"&&typeof define.amd=="object"?define(t):this[e]=t()}("domready",function(){var e=[],t,n=document,r=n.documentElement.doScroll,i="DOMContentLoaded",s=(r?/^loaded|^c/:/^loaded|^i|^c/).test(n.readyState);return s||n.addEventListener(i,t=function(){n.removeEventListener(i,t),s=1;while(t=e.shift())t()}),function(t){s?setTimeout(t,0):e.push(t)}})

--- a/ajax/libs/domready/package.json
+++ b/ajax/libs/domready/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "domready",
+  "filename": "ready.min.js",
+  "version": "1.0.8",
+  "homepage": "https://github.com/ded/domready",
+  "authors": "Dustin Diaz <dustin@dustindiaz.com> (http://dustindiaz.com)",
+  "description": "modern domready",
+  "keywords": [
+    "ender",
+    "domready",
+    "dom"
+  ],
+  "license": "MIT",
+  "repositories": [
+    {
+      "type": "git",
+      "url": "https://github.com/ded/domready"
+    }
+  ],
+  "autoupdate": {
+    "source": "git",
+    "target": "git://github.com/ded/domready.git",
+    "basePath": "",
+    "files": [
+      "ready*.js"
+    ]
+  }
+}


### PR DESCRIPTION
Hi @Piicksarn  , I add a new lib with git auto-update from the request #5251
repo: https://github.com/ded/domready
Would you mind checking this PR for me? Thank you~ :-)

- [x] Not found on cdnjs repo
- [x] No already exist issue and PR
- [x] Notable popularity : **Watch `31`, Star `609`, Fork `89`**
- [x] Project has public repository on famous online hosting platform (or been hosted on npm) 
- [x] Has valid tags for each versions (for git auto-update)
- [x] Auto-update setup
- [x] Auto-update target/source is valid.
- [x] Auto-update filemap is correct.