### PR TITLE
update package.json of prettify

### DIFF
--- a/ajax/libs/prettify/package.json
+++ b/ajax/libs/prettify/package.json
@@ -3,12 +3,16 @@
   "filename": "prettify.min.js",
   "version": "r298",
   "description": "A Javascript module and CSS file that allows syntax highlighting of source code snippets in an html page.",
-  "homepage": "http://code.google.com/p/google-code-prettify/",
+  "homepage": "https://github.com/google/code-prettify",
+  "license": "Apache-2.0",
   "keywords": [
-    "code syntax highlighting"
+    "code",
+    "syntax",
+    "highlighting",
+    "code-prettify"
   ],
   "repository": {
-    "type": "svn",
-    "url": "http://google-code-prettify.googlecode.com/svn/trunk/"
+    "type": "git",
+    "url": "https://github.com/google/code-prettify"
   }
 }


### PR DESCRIPTION
Hi @LeaYeh  , From #5420, I have updated info in package.json of prettify.
From #5500, I have added license info.
old repo : https://code.google.com/p/google-code-prettify
repo : https://github.com/google/code-prettify
The repo on GitHub don't have tags, so I don't add auto-update config.
Would you mind checking this PR for me? Thank you~ :-)

- [ ] Not found on cdnjs repo
- [x] No already exist issue and PR
- [x] Notable popularity : **Watch `31`, Star `443`, Fork `75`**
- [x] Project has public repository on famous online hosting platform (or been hosted on npm) 
- [ ] Has valid tags for each versions (for git auto-update)
- [ ] Auto-update setup
- [ ] Auto-update target/source is valid.
- [ ] Auto-update filemap is correct.