### PR TITLE
update license info of jquery.fancytree

### DIFF
--- a/ajax/libs/jquery.fancytree/package.json
+++ b/ajax/libs/jquery.fancytree/package.json
@@ -15,7 +15,7 @@
   "licenses": [
     {
       "type": "MIT",
-      "url": "https://code.google.com/p/fancytree/wiki/LicenseInfo"
+      "url": "http://opensource.org/licenses/mit-license.php"
     }
   ],
   "keywords": [


### PR DESCRIPTION
Hi @LeaYeh , From #5420 and #5500, I have updated license info of jquery.fancytree.
repo : https://github.com/mar10/fancytree
Would you mind checking this PR for me? Thank you~ :-)

- [ ] Not found on cdnjs repo
- [x] No already exist issue and PR
- [x] Notable popularity : **Watch `113`, Star `772`, Fork `222`**
- [x] Project has public repository on famous online hosting platform (or been hosted on npm) 
- [x] Has valid tags for each versions (for git auto-update)
- [x] Auto-update setup
- [x] Auto-update target/source is valid.
- [x] Auto-update filemap is correct.