### PR TITLE
[author] Add KaTeX Autoupdate

### DIFF
--- a/ajax/libs/KaTeX/package.json
+++ b/ajax/libs/KaTeX/package.json
@@ -14,5 +14,16 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/Khan/KaTeX.git"
+  },
+  "autoupdate": {
+    "source": "git",
+    "target": "git://github.com/Khan/KaTeX.git",
+    "basePath": "dist",
+    "files": [
+      "katex.min.js",
+      "katex.min.css",
+      "contrib/*",
+      "fonts/*"
+    ]
   }
 }


### PR DESCRIPTION
This adds an autoupdate section to the KaTeX package.json.

Some questions:
 - I didn't actually add the current version of KaTeX nor the intermediate versions which we have missed updating; do you want me to add the current one here?
 - Does the autoupdating look at the git tags from a repository? We have recently started actually committing built files in separate off-master commits that are tagged (which is why we didn't add auto-updating before!). Will that work? This also means that some older versions won't be able to be auto-updated, since the built files don't exist in the repository at those tags. Do you want me to add those manually?

Hopefully this works. Thanks!