### PR TITLE
Enrich backbone-tastypie's package.json(field: license)

### DIFF
--- a/ajax/libs/backbone-tastypie/package.json
+++ b/ajax/libs/backbone-tastypie/package.json
@@ -13,5 +13,6 @@
       "type": "git",
       "url": "https://github.com/PaulUithol/backbone-tastypie"
     }
-  ]
+  ],
+  "license": "MIT"
 }


### PR DESCRIPTION
#5500 
License link: [https://github.com/PaulUithol/backbone-tastypie/blob/master/LICENSE.txt](https://github.com/PaulUithol/backbone-tastypie/blob/master/LICENSE.txt)