### PR TITLE
Enrich backbone.eventbinder's package.json(field: license)

### DIFF
--- a/ajax/libs/backbone.eventbinder/package.json
+++ b/ajax/libs/backbone.eventbinder/package.json
@@ -18,5 +18,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/marionettejs/backbone.eventbinder"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
#5500
License link: [https://github.com/marionettejs/backbone.eventbinder/blob/master/LICENSE.md](https://github.com/marionettejs/backbone.eventbinder/blob/master/LICENSE.md)
