### PR TITLE
Enrich backbone.fetch-cache's package.json(field: license)

### DIFF
--- a/ajax/libs/backbone.fetch-cache/package.json
+++ b/ajax/libs/backbone.fetch-cache/package.json
@@ -13,5 +13,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/madglory/backbone-fetch-cache.git"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
#5500
License link: [https://github.com/madglory/backbone-fetch-cache/blob/master/LICENSE](https://github.com/madglory/backbone-fetch-cache/blob/master/LICENSE)