### PR TITLE
Enrich  backbone.layoutmanager's package.json(field: license)

### DIFF
--- a/ajax/libs/backbone.layoutmanager/package.json
+++ b/ajax/libs/backbone.layoutmanager/package.json
@@ -27,5 +27,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/tbranyen/backbone.layoutmanager"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
#5500 
license link: [https://github.com/tbranyen/backbone.layoutmanager/blob/master/LICENSE](https://github.com/tbranyen/backbone.layoutmanager/blob/master/LICENSE)