### PR TITLE
Enrich  backbone.marionette's package.json(field: license)

### DIFF
--- a/ajax/libs/backbone.marionette/package.json
+++ b/ajax/libs/backbone.marionette/package.json
@@ -29,5 +29,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/marionettejs/backbone.marionette"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
#5500 
license link: [https://github.com/marionettejs/backbone.marionette/blob/master/license.txt](https://github.com/marionettejs/backbone.marionette/blob/master/license.txt)