### PR TITLE
Change React auto-updating to use git

### DIFF
--- a/ajax/libs/react/package.json
+++ b/ajax/libs/react/package.json
@@ -15,13 +15,13 @@
   ],
   "homepage": "http://facebook.github.io/react",
   "npmName": "react",
-  "npmFileMap": [
-    {
-      "basePath": "/dist/",
-      "files": [
-        "*.js"
-      ]
-    }
-  ],
+  "autoupdate": {
+    "source": "git",
+    "target": "git://github.com/reactjs/react-bower.git",
+    "basePath": "",
+    "files": [
+      "*.js"
+    ]
+  },
   "namespace": "React"
 }


### PR DESCRIPTION
In facebook/react#4901 we're going to be moving `react-dom.js` outside of the `react` npm package. For now we'd like to keep that file still in the same project here on the CDN (and we're still distributing it with the `react` bower package). In order to do that we need to point the autoupdater at the repo we use for bower instead of npm.

I think the only difference here is that we store RCs here. We always published those to npm as well but because we never used the `latest` tag, they never ended up here.