### PR TITLE
Enrich backbone.modelbinder's package.json(field: license)

### DIFF
--- a/ajax/libs/backbone.modelbinder/package.json
+++ b/ajax/libs/backbone.modelbinder/package.json
@@ -27,5 +27,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/theironcook/Backbone.ModelBinder"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
#5500 
license link: [https://github.com/theironcook/Backbone.ModelBinder#legal-info-mit-license](https://github.com/theironcook/Backbone.ModelBinder#legal-info-mit-license]