### PR TITLE
Enrich aws-sdk's package.json(field: license)

### DIFF
--- a/ajax/libs/aws-sdk/package.json
+++ b/ajax/libs/aws-sdk/package.json
@@ -19,5 +19,6 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/aws/aws-sdk-js.git"
-  }
+  },
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
Hi @Piicksarn  , 
From #5500, I have added license info.
repo : https://github.com/aws/aws-sdk-js
Would you mind checking this PR for me? Thank you~ :-)

- [ ] Not found on cdnjs repo
- [x] No already exist issue and PR
- [x] Notable popularity : **Watch `149`, Star `1806`, Fork `287`**
- [x] Has valid tags for each versions (for git auto-update)
- [x] Auto-update setup
- [x] Auto-update target/source is valid.