### PR TITLE
Enrich backbone-forms's package.json(field: license)

### DIFF
--- a/ajax/libs/backbone-forms/package.json
+++ b/ajax/libs/backbone-forms/package.json
@@ -20,5 +20,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/powmedia/backbone-forms"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
Hi @Amomo  , 
For #5500 , I update the license.

backbone-forms use `"MIT License"`,
You can find this info from https://github.com/powmedia/backbone-forms/blob/master/LICENSE
repo : https://github.com/powmedia/backbone-forms

- [ ] Not found on cdnjs repo
- [x] No already exist issue and PR
- [x] Notable popularity : **Watch `104`, Star `2136`, Fork `423`**
- [x] Project has public repository on famous online hosting platform (or been hosted on npm) 
- [x] Has valid tags for each versions (for git auto-update)
- [x] Auto-update setup
- [x] Auto-update target/source is valid.
- [x] Auto-update filemap is correct.


Would you mind checking this PR for me? Thank you~ :-)