### PR TITLE
Enrich jqModal's package.json(field: license)

### DIFF
--- a/ajax/libs/jqModal/package.json
+++ b/ajax/libs/jqModal/package.json
@@ -24,5 +24,6 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/briceburg/jqModal.git"
-  }
+  },
+  "license": "GPL 2.0"
 }


### PR DESCRIPTION
Hi @Piicksarn   , 
For #5500 , I update the license.

backbone-forms use `"GPL 2.0 License"`,
You can find this info from https://github.com/briceburg/jqModal/blob/master/GPL-LICENSE.txt
repo : https://github.com/briceburg/jqModal

- [ ] Not found on cdnjs repo
- [x] No already exist issue and PR
- [x] Notable popularity : **Watch `6`, Star `48`, Fork `30`**
- [x] Has valid tags for each versions (for git auto-update)
- [x] Auto-update setup
- [x] Auto-update target/source is valid.