### PR TITLE
Enrich bootstrap-confirmation's package.json(field: license)

### DIFF
--- a/ajax/libs/bootstrap-confirmation/package.json
+++ b/ajax/libs/bootstrap-confirmation/package.json
@@ -26,5 +26,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/tavicu/bs-confirmation.git"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
Hi @Amomo  , 
For #5500 , I update the license.

bootstrap-confirmation use `"MIT License"`,
You can find this info from https://github.com/tavicu/bs-confirmation#copyright-and-license

- [ ] Not found on cdnjs repo
- [x] No already exist issue and PR
- [x] Notable popularity : **Watch `14`, Star `79`, Fork `37`**
- [x] Has valid tags for each versions (for git auto-update)
- [x] Auto-update setup
- [x] Auto-update target/source is valid.
- [x] Auto-update filemap is correct.


Would you mind checking this PR for me?