### PR TITLE
add homepage & keywords & git auto-update in unveil

### DIFF
--- a/ajax/libs/unveil/package.json
+++ b/ajax/libs/unveil/package.json
@@ -4,7 +4,7 @@
   "description": "A very lightweight jQuery plugin to lazy load images",
   "version": "1.3.0",
   "homepage": "http://luis-almeida.github.io/unveil/",
-  "authod": "Luís Almeida",
+  "author": "Luís Almeida",
   "keywords": [
     "lazyload",
     "jquery",

--- a/ajax/libs/unveil/package.json
+++ b/ajax/libs/unveil/package.json
@@ -17,5 +17,13 @@
   "dependencies": {
     "jquery": ">= 1.9.0"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "autoupdate": {
+    "source": "git",
+    "target": "git://github.com/luis-almeida/unveil.git",
+    "basePath": "",
+    "files": [
+      "jquery.unveil*.js"
+    ]
+  }
 }

--- a/ajax/libs/unveil/package.json
+++ b/ajax/libs/unveil/package.json
@@ -3,7 +3,13 @@
   "filename": "jquery.unveil.min.js",
   "description": "A very lightweight jQuery plugin to lazy load images",
   "version": "1.3.0",
+  "homepage": "http://luis-almeida.github.io/unveil/",
   "authod": "Luís Almeida",
+  "keywords": [
+    "lazyload",
+    "jquery",
+    "retina"
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/luis-almeida/unveil"


### PR DESCRIPTION
Hi @Piicksarn `unveil` is a lib aleady in cdnjs.
repo: https://github.com/luis-almeida/unveil

For #5422, because unveil don't provide keywords in its repo.
I pick some words from README.md as keywords.

And, I found some typo in the "author" field, so I corrected it.

For #5818, I add git auto-update config in the package.json.

Would you mind checking this PR for me? Thank you~ :-D

- [ ] Not found on cdnjs repo
- [x] No already exist issue and PR
- [x] Notable popularity : **Watch `148`, Star `3,378`, Fork `522`**
- [x] Project has public repository on famous online hosting platform (or been hosted on npm) 
- [x] Has valid tags for each versions (for git auto-update)
- [x] Auto-update setup
- [x] Auto-update target/source is valid.
- [x] Auto-update filemap is correct.