### PR TITLE
Enrich backbone.syphon's package.json(field: license)

### DIFF
--- a/ajax/libs/backbone.syphon/package.json
+++ b/ajax/libs/backbone.syphon/package.json
@@ -17,5 +17,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/derickbailey/backbone.syphon"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
#5500 
license link: [https://github.com/marionettejs/backbone.syphon/blob/master/package.json](https://github.com/marionettejs/backbone.syphon/blob/master/package.json)