### PR TITLE
Enrich entypo's package.json(field: license)

### DIFF
--- a/ajax/libs/entypo/package.json
+++ b/ajax/libs/entypo/package.json
@@ -13,5 +13,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/danielbruce/entypo.git"
-  }
+  },
+  "licence": "CC-BY-SA-4.0"
 }


### PR DESCRIPTION
Hi @Piicksarn  , 
From #5500, I have added license info. http://www.entypo.com/
with licence `CC-BY-SA-4.0`
repo : https://github.com/danielbruce/entypo
Would you mind checking this PR for me? Thank you.