### PR TITLE
[author] Update remoteStorage's license

### DIFF
--- a/ajax/libs/remoteStorage/package.json
+++ b/ajax/libs/remoteStorage/package.json
@@ -4,10 +4,7 @@
   "filename": "remotestorage.min.js",
   "description": "Client-side Javascript library to make apps remoteStorage-compatible.",
   "homepage": "http://remotestorage.io/",
-  "licenses": [
-    "AGPL-3.0",
-    "MIT"
-  ],
+  "license": "MIT",
   "keywords": [
     "remoteStorage",
     "unhosted",


### PR DESCRIPTION
@PeterDaveHello, I mistakenly thought remoteStorage still had two licenses, but I was wrong. Sorry. Here is another PR to fix it.

I've updated package.json to match the right license: MIT.

Thanks a bunch!