### PR TITLE
Update package.json of jQuery.mmenu

### DIFF
--- a/ajax/libs/jQuery.mmenu/package.json
+++ b/ajax/libs/jQuery.mmenu/package.json
@@ -23,8 +23,7 @@
     "target": "git://github.com/BeSite/jQuery.mmenu.git",
     "basePath": "dist",
     "files": [
-      "css/**/*",
-      "js/**/*"
+      "**/*"
     ]
   },
   "repository": {


### PR DESCRIPTION
Hi. I noticed that the latest version of jQuery.mmenu library is not available on cdnjs.

The directory structure has been changed since jQuery.mmenu v5.4.0 and auto update is not working after that. This pull request fixes auto update settings of the library.

- Latest version
  - https://github.com/BeSite/jQuery.mmenu/tree/v5.5.2/dist
- Latest available version on cdnjs
  - https://github.com/BeSite/jQuery.mmenu/tree/v5.3.4/dist