### PR TITLE
Enrich Clamp.js' package.json(field: license)

### DIFF
--- a/ajax/libs/Clamp.js/package.json
+++ b/ajax/libs/Clamp.js/package.json
@@ -27,5 +27,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/josephschmitt/Clamp.js.git"
-  }
+  },
+  "license": "WTFPL"
 }


### PR DESCRIPTION
Hi @maruilian11 , 
From #5500, I have added license info. https://github.com/josephschmitt/Clamp.js/blob/master/clamp.js#L5
repo : https://github.com/josephschmitt/Clamp.js
Would you mind checking this PR for me? Thank you.