### PR TITLE
Update shaka-player package.json to include new build variants

### DIFF
--- a/ajax/libs/shaka-player/package.json
+++ b/ajax/libs/shaka-player/package.json
@@ -15,7 +15,9 @@
     {
       "basePath": "/",
       "files": [
-        "shaka-player.compiled.js"
+        "shaka-player.compiled.js",
+        "shaka-player.vod.js",
+        "shaka-player.live.js"
       ]
     }
   ]


### PR DESCRIPTION
Shaka Player v1.6.0 includes new build variants that should be distributed on cdnjs.

See also google/shaka-player#116