### PR TITLE
Add jquery-boilerplate@3.5.0 with git autoupdate

### DIFF
--- a/ajax/libs/jquery-boilerplate/3.5.0/jquery.boilerplate.js
+++ b/ajax/libs/jquery-boilerplate/3.5.0/jquery.boilerplate.js
@@ -1,0 +1,69 @@
+/*
+ *  jquery-boilerplate - v3.4.0
+ *  A jump-start for jQuery plugins development.
+ *  http://jqueryboilerplate.com
+ *
+ *  Made by Zeno Rocha
+ *  Under MIT License
+ */
+// the semi-colon before function invocation is a safety net against concatenated
+// scripts and/or other plugins which may not be closed properly.
+;(function ( $, window, document, undefined ) {
+
+	"use strict";
+
+		// undefined is used here as the undefined global variable in ECMAScript 3 is
+		// mutable (ie. it can be changed by someone else). undefined isn't really being
+		// passed in so we can ensure the value of it is truly undefined. In ES5, undefined
+		// can no longer be modified.
+
+		// window and document are passed through as local variable rather than global
+		// as this (slightly) quickens the resolution process and can be more efficiently
+		// minified (especially when both are regularly referenced in your plugin).
+
+		// Create the defaults once
+		var pluginName = "defaultPluginName",
+				defaults = {
+				propertyName: "value"
+		};
+
+		// The actual plugin constructor
+		function Plugin ( element, options ) {
+				this.element = element;
+				// jQuery has an extend method which merges the contents of two or
+				// more objects, storing the result in the first object. The first object
+				// is generally empty as we don't want to alter the default options for
+				// future instances of the plugin
+				this.settings = $.extend( {}, defaults, options );
+				this._defaults = defaults;
+				this._name = pluginName;
+				this.init();
+		}
+
+		// Avoid Plugin.prototype conflicts
+		$.extend(Plugin.prototype, {
+				init: function () {
+						// Place initialization logic here
+						// You already have access to the DOM element and
+						// the options via the instance, e.g. this.element
+						// and this.settings
+						// you can add more functions like the one below and
+						// call them like so: this.yourOtherFunction(this.element, this.settings).
+						console.log("xD");
+				},
+				yourOtherFunction: function () {
+						// some logic
+				}
+		});
+
+		// A really lightweight plugin wrapper around the constructor,
+		// preventing against multiple instantiations
+		$.fn[ pluginName ] = function ( options ) {
+				return this.each(function() {
+						if ( !$.data( this, "plugin_" + pluginName ) ) {
+								$.data( this, "plugin_" + pluginName, new Plugin( this, options ) );
+						}
+				});
+		};
+
+})( jQuery, window, document );

--- a/ajax/libs/jquery-boilerplate/3.5.0/jquery.boilerplate.min.js
+++ b/ajax/libs/jquery-boilerplate/3.5.0/jquery.boilerplate.min.js
@@ -1,0 +1,9 @@
+/*
+ *  jquery-boilerplate - v3.4.0
+ *  A jump-start for jQuery plugins development.
+ *  http://jqueryboilerplate.com
+ *
+ *  Made by Zeno Rocha
+ *  Under MIT License
+ */
+!function(a){"use strict";function b(b,e){this.element=b,this.settings=a.extend({},d,e),this._defaults=d,this._name=c,this.init()}var c="defaultPluginName",d={propertyName:"value"};a.extend(b.prototype,{init:function(){console.log("xD")},yourOtherFunction:function(){}}),a.fn[c]=function(d){return this.each(function(){a.data(this,"plugin_"+c)||a.data(this,"plugin_"+c,new b(this,d))})}}(jQuery,window,document);

--- a/ajax/libs/jquery-boilerplate/package.json
+++ b/ajax/libs/jquery-boilerplate/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "jquery-boilerplate",
+  "filename": "jquery.boilerplate.min.js",
+  "version": "3.5.0",
+  "description": "A jump-start for jQuery plugins development.",
+  "keywords": [
+    "jquery-plugin",
+    "jquery",
+    "boilerplate",
+    "plugins"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jquery-boilerplate/jquery-boilerplate.git"
+  },
+  "author": {
+    "name": "Zeno Rocha",
+    "email": "zno.rocha@gmail.com",
+    "url": "https://github.com/zenorocha"
+  },
+  "homepage": "http://jqueryboilerplate.com",
+  "license": "MIT",
+  "autoupdate": {
+    "source": "git",
+    "target": "git://github.com/jquery-boilerplate/jquery-boilerplate.git",
+    "basePath": "dist",
+    "files": [
+      "**/*"
+    ]
+  }
+}


### PR DESCRIPTION
@Amomo  , would you mind to have a look at the pr?
The PR is referenced to issue  #6121
The git repo : https://github.com/jquery-boilerplate/jquery-boilerplate/tree/v3.5.0

- [x] Not found on cdnjs repo
- [x] No already exist issue and PR
- [x] Notable popularity : **Watch `107`, Star `2272`, Fork `496`**
- [x] Project has public repository on famous online hosting platform (or been hosted on npm) 
- [x] Has valid tags for each versions (for git auto-update)
- [x] Auto-update setup
- [x] Auto-update target/source is valid.
- [x] Auto-update filemap is correct.

Thank you!