### PR TITLE
Update package.json to include *.map files

### DIFF
--- a/ajax/libs/free-jqgrid/package.json
+++ b/ajax/libs/free-jqgrid/package.json
@@ -5,12 +5,13 @@
     {
       "basePath": "/",
       "files": [
-        "css/ui.jqgrid.css",
+        "css/*",
         "js/jquery.jqgrid.min.js",
         "js/jquery.jqgrid.min.map",
         "js/jquery.jqgrid.src.js",
         "js/i18n/*.js",
-        "plugins/*.*"
+        "js/i18n/*.map",
+        "plugins/*"
       ]
     }
   ],


### PR DESCRIPTION
The next version of free jqGrid will provide *.map to all *.js and *.css files.