### PR TITLE
Enrich jquery.smartbanner's package.json(field: license)

### DIFF
--- a/ajax/libs/jquery.smartbanner/package.json
+++ b/ajax/libs/jquery.smartbanner/package.json
@@ -28,5 +28,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/jasny/jquery.smartbanner"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
#5500 
license link: [https://github.com/jasny/jquery.smartbanner/blob/master/LICENSE](https://github.com/jasny/jquery.smartbanner/blob/master/LICENSE)
[https://github.com/jasny/jquery.smartbanner/search?utf8=%E2%9C%93&q=MIT](https://github.com/jasny/jquery.smartbanner/search?utf8=%E2%9C%93&q=MIT)