### PR TITLE
modify npm auto-update example to fit test format

### DIFF
--- a/CONTRIBUTING-WIP.md
+++ b/CONTRIBUTING-WIP.md
@@ -37,12 +37,14 @@ Each cdnjs library has a `package.json` file. This file contains required and so
 
 ```js
   "npmName": "lodash",
-  "npmFileMap": [{
-    "basePath": "/dist/",
-    "files": [
-      "*.js"
-    ]
-  }],
+  "npmFileMap": [
+    {
+      "basePath": "/dist/",
+      "files": [
+        "*.js"
+      ]
+    }
+  ],
 ```
 
 The example in 2.3. parses the `lodash` tarball, which has this structure:


### PR DESCRIPTION
old version can't pass the test