### PR TITLE
[new] add angular-morris-chart@1.1.4 with npm auto-update

### DIFF
--- a/ajax/libs/angular-morris-chart/1.1.4/angular-morris-chart.js
+++ b/ajax/libs/angular-morris-chart/1.1.4/angular-morris-chart.js
@@ -1,0 +1,311 @@
+/**
+ * angular morris chart provides morris.js wrappers directives for angular
+ * check out documentation in http://angular-morris-chart.stpa.co
+ *
+ * Copyright © 2014 Stewan Pacheco <talk@stpa.co>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+"use strict";
+(function() {
+    angular.module('angular.morris-chart', []);
+})();
+/**
+ * angular morris chart provides morris.js wrappers directives for angular
+ * check out documentation in http://angular-morris-chart.stpa.co
+ *
+ * Copyright © 2014 Stewan Pacheco <talk@stpa.co>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+"use strict";
+/* global Morris */
+(function() {
+    angular.module("angular.morris-chart").directive('areaChart',
+        function() {
+            return {
+                restrict: 'A',
+                scope: {
+                    areaData: '=',
+                    areaXkey: '@',
+                    areaYkeys: '=',
+                    areaLabels: '=',
+                    lineColors: '='
+                },
+                link: function(scope, elem) {
+                    scope.$watch('areaData', function() {
+                        if (scope.areaData) {
+                            if (typeof scope.areaData === 'string')
+                                scope.areaData = JSON.parse(scope.areaData);
+                            if (typeof scope.areaYkeys === 'string')
+                                scope.areaYkeys = JSON.parse(scope.areaYkeys);
+                            if (typeof scope.areaLabels === 'string')
+                                scope.areaLabels = JSON.parse(scope.areaLabels);
+                            if (typeof scope.lineColors === 'string')
+                                scope.lineColors = JSON.parse(scope.lineColors);
+
+                            if (!scope.areaInstance) {
+                                scope.areaInstance = new Morris.Area({
+                                    element: elem,
+                                    data: scope.areaData,
+                                    xkey: scope.areaXkey,
+                                    ykeys: scope.areaYkeys,
+                                    labels: scope.areaLabels,
+                                    lineColors: scope.lineColors || ['#0b62a4', '#7a92a3', '#4da74d', '#afd8f8', '#edc240', '#cb4b4b', '#9440ed']
+                                });
+                            } else {
+                                scope.areaInstance.setData(scope.areaData);
+                            }
+                        }
+                    });
+                }
+            }
+        });
+})();
+/**
+ * angular morris chart provides morris.js wrappers directives for angular
+ * check out documentation in http://angular-morris-chart.stpa.co
+ *
+ * Copyright © 2014 Stewan Pacheco <talk@stpa.co>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+"use strict";
+/* global Morris */
+(function() {
+    angular.module("angular.morris-chart").directive('barChart', function() {
+        return {
+            restrict: 'A',
+            scope: {
+                barX: '@',
+                barY: '=',
+                barLabels: '=',
+                barData: '=',
+                barColors: '=',
+                barStacked: '=',
+                barResize: '='
+            },
+            link: function(scope, elem) {
+                scope.$watch('barData', function() {
+                    if (scope.barData) {
+                        if (typeof scope.barY === 'string')
+                            scope.barY = JSON.parse(scope.barY);
+                        if (typeof scope.barLabels === 'string')
+                            scope.barLabels = JSON.parse(scope.barLabels);
+                        if (typeof scope.barData === 'string')
+                            scope.barData = JSON.parse(scope.barData);
+                        if (typeof scope.barColors === 'string')
+                            scope.barColors = JSON.parse(scope.barColors);
+                        if (typeof scope.barStacked === 'string')
+                            scope.barStacked = JSON.parse(scope.barStacked);
+                        if (typeof scope.barResize === 'string')
+                            scope.barResize = JSON.parse(scope.barResize);
+                        if (!scope.barInstance) {
+                            scope.barInstance = new Morris.Bar({
+                                element: elem,
+                                data: scope.barData,
+                                xkey: scope.barX,
+                                ykeys: scope.barY,
+                                labels: scope.barLabels,
+                                barColors: scope.barColors || ['#0b62a4', '#7a92a3', '#4da74d', '#afd8f8', '#edc240', '#cb4b4b', '#9440ed'],
+                                stacked: scope.barStacked || false,
+                                resize: scope.barResize || false,
+                                xLabelMargin: 2
+                            });
+                        } else {
+                            scope.barInstance.setData(scope.barData);
+                        }
+                    }
+                })
+            }
+        }
+    })
+})();
+/**
+ * angular morris chart provides morris.js wrappers directives for angular
+ * check out documentation in http://angular-morris-chart.stpa.co
+ *
+ * Copyright © 2014 Stewan Pacheco <talk@stpa.co>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+"use strict";
+/* global Morris */
+(function() {
+    angular.module("angular.morris-chart").directive('donutChart', /*@ngInject*/function($injector) {
+        return {
+            restrict: 'A',
+            scope: {
+                donutData: '=',
+                donutColors: '=',
+                donutFormatter: '='
+            },
+            link: function(scope, elem) {
+                scope.$watch('donutData', function() {
+                    if (scope.donutData) {
+                        if (typeof scope.donutData === 'string')
+                            scope.donutData = JSON.parse(scope.donutData);
+
+                        if (typeof scope.donutColors === 'string')
+                            scope.donutColors = JSON.parse(scope.donutColors);
+
+                        if (!scope.donutInstance) {
+                            var options = {
+                                element: elem,
+                                data: scope.donutData,
+                                colors: scope.donutColors || ['#0b62a4', '#7a92a3', '#4da74d', '#afd8f8', '#edc240', '#cb4b4b', '#9440ed']
+                            };
+                            // Check if a formatter function has been set
+                            if (typeof scope.donutFormatter === 'function') {
+                                options.formatter = scope.donutFormatter;
+                            } else if (typeof scope.donutFormatter === 'string' && $injector.has(scope.donutFormatter + 'Filter')) {
+                                // If the formatter is a string, check for a matching filter
+                                var filter = $injector.get(scope.donutFormatter + 'Filter');
+                                options.formatter = function (input) {
+                                    return filter.call(this, input);
+                                };
+                            }
+                            scope.donutInstance = new Morris.Donut(options);
+                        } else {
+                            scope.donutInstance.setData(scope.donutData);
+                        }
+                    }
+                })
+            }
+        }
+    })
+})();
+/**
+ * angular morris chart provides morris.js wrappers directives for angular
+ * check out documentation in http://angular-morris-chart.stpa.co
+ *
+ * Copyright © 2014 Stewan Pacheco <talk@stpa.co>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+"use strict";
+/* global Morris */
+(function() {
+    angular.module("angular.morris-chart").directive('lineChart',
+        function() {
+            return {
+                restrict: 'A',
+                scope: {
+                    lineData: '=',
+                    lineXkey: '@',
+                    lineYkeys: '=',
+                    lineLabels: '=',
+                    lineColors: '='
+                },
+                link: function(scope, elem) {
+                    scope.$watch('lineData', function() {
+                        if (scope.lineData) {
+                            if (typeof scope.lineData === 'string')
+                                scope.lineData = JSON.parse(scope.lineData);
+                            if (typeof scope.lineYkeys === 'string')
+                                scope.lineYkeys = JSON.parse(scope.lineYkeys);
+                            if (typeof scope.lineYkeys === 'string')
+                                scope.lineYkeys = JSON.parse(scope.lineYkeys);
+                            if (typeof scope.lineLabels === 'string')
+                                scope.lineLabels = JSON.parse(scope.lineLabels);
+                            if (typeof scope.lineColors === 'string')
+                                scope.lineColors = JSON.parse(scope.lineColors);
+                            if (!scope.lineInstance) {
+                                scope.lineInstance = new Morris.Line({
+                                    element: elem,
+                                    data: scope.lineData,
+                                    xkey: scope.lineXkey,
+                                    ykeys: scope.lineYkeys,
+                                    labels: scope.lineLabels,
+                                    lineColors: scope.lineColors || ['#0b62a4', '#7a92a3', '#4da74d', '#afd8f8', '#edc240', '#cb4b4b', '#9440ed']
+                                });
+                            } else {
+                                scope.lineInstance.setData(scope.lineData);
+                            }
+                        }
+                    });
+                }
+            }
+        }
+    )
+})();

--- a/ajax/libs/angular-morris-chart/1.1.4/angular-morris-chart.min.js
+++ b/ajax/libs/angular-morris-chart/1.1.4/angular-morris-chart.min.js
@@ -1,0 +1,25 @@
+/**
+ * angular morris chart provides morris.js wrappers directives for angular
+ * check out documentation in http://angular-morris-chart.stpa.co
+ *
+ * Copyright © 2014 Stewan Pacheco <talk@stpa.co>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+"use strict";!function(){angular.module("angular.morris-chart",[])}(),function(){angular.module("angular.morris-chart").directive("areaChart",function(){return{restrict:"A",scope:{areaData:"=",areaXkey:"@",areaYkeys:"=",areaLabels:"=",lineColors:"="},link:function(a,e){a.$watch("areaData",function(){a.areaData&&("string"==typeof a.areaData&&(a.areaData=JSON.parse(a.areaData)),"string"==typeof a.areaYkeys&&(a.areaYkeys=JSON.parse(a.areaYkeys)),"string"==typeof a.areaLabels&&(a.areaLabels=JSON.parse(a.areaLabels)),"string"==typeof a.lineColors&&(a.lineColors=JSON.parse(a.lineColors)),a.areaInstance?a.areaInstance.setData(a.areaData):a.areaInstance=new Morris.Area({element:e,data:a.areaData,xkey:a.areaXkey,ykeys:a.areaYkeys,labels:a.areaLabels,lineColors:a.lineColors||["#0b62a4","#7a92a3","#4da74d","#afd8f8","#edc240","#cb4b4b","#9440ed"]}))})}}})}(),function(){angular.module("angular.morris-chart").directive("barChart",function(){return{restrict:"A",scope:{barX:"@",barY:"=",barLabels:"=",barData:"=",barColors:"=",barStacked:"=",barResize:"="},link:function(a,e){a.$watch("barData",function(){a.barData&&("string"==typeof a.barY&&(a.barY=JSON.parse(a.barY)),"string"==typeof a.barLabels&&(a.barLabels=JSON.parse(a.barLabels)),"string"==typeof a.barData&&(a.barData=JSON.parse(a.barData)),"string"==typeof a.barColors&&(a.barColors=JSON.parse(a.barColors)),"string"==typeof a.barStacked&&(a.barStacked=JSON.parse(a.barStacked)),"string"==typeof a.barResize&&(a.barResize=JSON.parse(a.barResize)),a.barInstance?a.barInstance.setData(a.barData):a.barInstance=new Morris.Bar({element:e,data:a.barData,xkey:a.barX,ykeys:a.barY,labels:a.barLabels,barColors:a.barColors||["#0b62a4","#7a92a3","#4da74d","#afd8f8","#edc240","#cb4b4b","#9440ed"],stacked:a.barStacked||!1,resize:a.barResize||!1,xLabelMargin:2}))})}}})}(),function(){angular.module("angular.morris-chart").directive("donutChart",["$injector",function(a){return{restrict:"A",scope:{donutData:"=",donutColors:"=",donutFormatter:"="},link:function(e,r){e.$watch("donutData",function(){if(e.donutData)if("string"==typeof e.donutData&&(e.donutData=JSON.parse(e.donutData)),"string"==typeof e.donutColors&&(e.donutColors=JSON.parse(e.donutColors)),e.donutInstance)e.donutInstance.setData(e.donutData);else{var t={element:r,data:e.donutData,colors:e.donutColors||["#0b62a4","#7a92a3","#4da74d","#afd8f8","#edc240","#cb4b4b","#9440ed"]};if("function"==typeof e.donutFormatter)t.formatter=e.donutFormatter;else if("string"==typeof e.donutFormatter&&a.has(e.donutFormatter+"Filter")){var n=a.get(e.donutFormatter+"Filter");t.formatter=function(a){return n.call(this,a)}}e.donutInstance=new Morris.Donut(t)}})}}}])}(),function(){angular.module("angular.morris-chart").directive("lineChart",function(){return{restrict:"A",scope:{lineData:"=",lineXkey:"@",lineYkeys:"=",lineLabels:"=",lineColors:"="},link:function(a,e){a.$watch("lineData",function(){a.lineData&&("string"==typeof a.lineData&&(a.lineData=JSON.parse(a.lineData)),"string"==typeof a.lineYkeys&&(a.lineYkeys=JSON.parse(a.lineYkeys)),"string"==typeof a.lineYkeys&&(a.lineYkeys=JSON.parse(a.lineYkeys)),"string"==typeof a.lineLabels&&(a.lineLabels=JSON.parse(a.lineLabels)),"string"==typeof a.lineColors&&(a.lineColors=JSON.parse(a.lineColors)),a.lineInstance?a.lineInstance.setData(a.lineData):a.lineInstance=new Morris.Line({element:e,data:a.lineData,xkey:a.lineXkey,ykeys:a.lineYkeys,labels:a.lineLabels,lineColors:a.lineColors||["#0b62a4","#7a92a3","#4da74d","#afd8f8","#edc240","#cb4b4b","#9440ed"]}))})}}})}();

--- a/ajax/libs/angular-morris-chart/package.json
+++ b/ajax/libs/angular-morris-chart/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "angular-morris-chart",
+  "version": "1.1.4",
+  "filename": "angular-morris-chart.min.js",
+  "description": "Wrapper of morris.js for AngularJS",
+  "homepage": "https://angular-morris-chart.stpa.co/",
+  "authors": "Stewan Pacheco <talk@stpa.co>",
+  "license": "MIT",
+  "keywords": [
+    "angular",
+    "morris",
+    "chart"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stewones/angular-morris-chart"
+  },
+  "npmName": "angular-morris-chart",
+  "npmFileMap": [
+    {
+      "basePath": "src/",
+      "files": [
+        "angular-morris-chart*.js"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Hi @LeaYeh 

For #6059, I add angular-morris-chart at v1.1.4  and add `npm` auto-update config in its package.json.
repo: https://github.com/stewones/angular-morris-chart
npm package url: https://www.npmjs.com/package/angular-morris-chart

Would you mind checking this PR for me? Thank you~ :-D

- [x] Not found on cdnjs repo
- [x] No already exist issue and PR
- [x] Notable popularity : **Watch `8`, Star `96`, Fork `36`**
- [x] Project has public repository on famous online hosting platform (or been hosted on npm) 
- [x] Has valid tags for each versions (for git auto-update)
- [x] Auto-update setup
- [x] Auto-update target/source is valid.
- [x] Auto-update filemap is correct.