### PR TITLE
add npm auto-update & update package.json of typescript

### DIFF
--- a/ajax/libs/typescript/package.json
+++ b/ajax/libs/typescript/package.json
@@ -11,6 +11,6 @@
   ],
   "repository": {
     "type": "git",
-    "url": "http://typescript.codeplex.com"
+    "url": "https://github.com/Microsoft/TypeScript"
   }
 }

--- a/ajax/libs/typescript/package.json
+++ b/ajax/libs/typescript/package.json
@@ -5,6 +5,8 @@
   "version": "1.0.0",
   "description": "TypeScript is a typed superset of JavaScript that compiles to plain JavaScript",
   "homepage": "http://www.typescriptlang.org",
+  "author": "Microsoft Corp.",
+  "license": "Apache-2.0",
   "keywords": [
     "compiler",
     "language"

--- a/ajax/libs/typescript/package.json
+++ b/ajax/libs/typescript/package.json
@@ -12,5 +12,14 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/Microsoft/TypeScript"
-  }
+  },
+  "npmName": "typescript",
+  "npmFileMap": [
+    {
+      "basePath": "lib/",
+      "files": [
+        "typescript*.js"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Hi @maruilian11 

"typescript" is a library already on cdnjs, but it don't have auto-update config.
repo: https://github.com/Microsoft/TypeScript
npm package url: https://www.npmjs.com/package/typescript

For #6102 and #6238, I add `npm` auto-update config in typescript's package.json.
For #5500, I add license info in the package.json.
Also, I modify the "repository" field to its GitHub repo, and add "author" field.

Would you mind checking this PR for me? Thank you~ :-D

- [ ] Not found on cdnjs repo
- [x] No already exist issue and PR
- [x] Notable popularity : **Watch `694`, Star `7,762`, Fork `899`**
- [x] Project has public repository on famous online hosting platform (or been hosted on npm) 
- [x] Has valid tags for each versions (for git auto-update)
- [x] Auto-update setup
- [x] Auto-update target/source is valid.
- [x] Auto-update filemap is correct.