### PR TITLE
add license info of Uniform.js

### DIFF
--- a/ajax/libs/Uniform.js/package.json
+++ b/ajax/libs/Uniform.js/package.json
@@ -10,5 +10,6 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/pixelmatrix/uniform.git"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
#6324 
License type: MIT

Source: https://github.com/pixelmatrix/uniform#uniform