### PR TITLE
add license info to batman.js

### DIFF
--- a/ajax/libs/batman.js/package.json
+++ b/ajax/libs/batman.js/package.json
@@ -22,5 +22,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/batmanjs/batman"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
PR for #6324 
Hi,
license of batman.js is referenced from
https://github.com/batmanjs/batman#license
