### PR TITLE
add license to eve.js

### DIFF
--- a/ajax/libs/eve.js/package.json
+++ b/ajax/libs/eve.js/package.json
@@ -22,5 +22,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/Yuffster/Eve.js"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
#6324

[ref](https://github.com/Yuffster/Eve.js/blob/master/MIT_LICENSE.txt)