### PR TITLE
add missing license of bean

### DIFF
--- a/ajax/libs/bean/package.json
+++ b/ajax/libs/bean/package.json
@@ -13,6 +13,7 @@
     "type": "git",
     "url": "https://github.com/fat/bean.git"
   },
+  "license": "MIT",
   "keywords": [
     "ender",
     "events",


### PR DESCRIPTION
#6324
add missing license of bean
[License](https://github.com/fat/bean/blob/master/LICENSE)