### PR TITLE
add missing liscense info of gumby

### DIFF
--- a/ajax/libs/gumby/package.json
+++ b/ajax/libs/gumby/package.json
@@ -20,5 +20,4 @@
     "url": "https://github.com/GumbyFramework/Gumby.git"
   },
   "license":"MIT"
-
 }

--- a/ajax/libs/gumby/package.json
+++ b/ajax/libs/gumby/package.json
@@ -19,5 +19,5 @@
     "type": "git",
     "url": "https://github.com/GumbyFramework/Gumby.git"
   },
-  "license":"MIT"
+  "license": "MIT"
 }

--- a/ajax/libs/gumby/package.json
+++ b/ajax/libs/gumby/package.json
@@ -18,5 +18,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/GumbyFramework/Gumby.git"
-  }
+  },
+  "license":"MIT"
+
 }


### PR DESCRIPTION
note: https://github.com/GumbyFramework/Gumby