### PR TITLE
add missing license info of gumby

### DIFF
--- a/ajax/libs/gumby/package.json
+++ b/ajax/libs/gumby/package.json
@@ -19,4 +19,5 @@
     "type": "git",
     "url": "https://github.com/GumbyFramework/Gumby.git"
   }
+  "license": "MIT"
 }


### PR DESCRIPTION
for #6324 
note: https://github.com/GumbyFramework/Gumby