### PR TITLE
add missing license info of gumby

### DIFF
--- a/ajax/libs/gumby/package.json
+++ b/ajax/libs/gumby/package.json
@@ -18,5 +18,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/GumbyFramework/Gumby.git"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
for #6324
note: https://github.com/GumbyFramework/Gumby