### PR TITLE
add missing license of bitcoinjs-lib

### DIFF
--- a/ajax/libs/bitcoinjs-lib/package.json
+++ b/ajax/libs/bitcoinjs-lib/package.json
@@ -14,5 +14,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/bitcoinjs/bitcoinjs-lib.git"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
PR for #6324
license info ref: https://github.com/bitcoinjs/bitcoinjs-lib#license