### PR TITLE
Add auto-update config and licence into jquery-hashchange

### DIFF
--- a/ajax/libs/jquery-hashchange/package.json
+++ b/ajax/libs/jquery-hashchange/package.json
@@ -18,5 +18,17 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/cowboy/jquery-hashchange"
+  },
+  "licences": [
+    "MIT",
+    "GPL-2.0"
+  ],
+  "autoupdate": {
+    "source": "git",
+    "target": "git://github.com/cowboy/jquery-hashchange.git",
+    "basePath": "",
+    "files": [
+      "jquery.ba-hashchange*.js"
+    ]
   }
 }


### PR DESCRIPTION
**git repo url:** https://github.com/cowboy/jquery-hashchange/tree/v1.3
**Watch 58
 Star 1101
 Fork 246**
@Amomo   could you help me check out the PR for #6197   ? thank you~
- [ ] Not found on cdnjs repo
- [x] No already exist issue and PR
- [x] Notable popularity 
- [x] Project has public repository on famous online hosting platform (or been hosted on npm) 
- [x] Has valid tags for each versions (for git auto-update)
- [x] Auto-update setup
- [x] Auto-update target/source is valid.
- [x] Auto-update filemap is correct