### PR TITLE
fix repository url of jqPlot

### DIFF
--- a/ajax/libs/jqPlot/package.json
+++ b/ajax/libs/jqPlot/package.json
@@ -19,6 +19,6 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://bitbucket.org/cleonello/jqplot/downloads/"
+    "url": "https://github.com/jqPlot/jqPlot/"
   }
 }


### PR DESCRIPTION
Hi @Piicksarn , this PR is for #6097
I have update the url of repository to a correct url in package.json.
repo: https://github.com/jqPlot/jqPlot

I didn't add auto-update config because the repo don't have tags.
However, they are planning to have tags!
https://github.com/jqPlot/jqPlot/issues/28

Would you mind checking this PR for me? Thank you~ :-D

- [ ] Not found on cdnjs repo
- [x] No already exist issue and PR
- [x] Notable popularity : **Watch `14`, Star `41`, Fork `18`**
- [x] Project has public repository on famous online hosting platform (or been hosted on npm) 
- [ ] Has valid tags for each versions (for git auto-update)
- [ ] Auto-update setup
- [ ] Auto-update target/source is valid.
- [ ] Auto-update filemap is correct.