### PR TITLE
modify auto-update config to npm of jsrender

### DIFF
--- a/ajax/libs/jsrender/package.json
+++ b/ajax/libs/jsrender/package.json
@@ -25,12 +25,14 @@
   "dependencies": {
     "through2": "^2.0.0"
   },
-  "autoupdate": {
-    "source": "git",
-    "target": "git://github.com/borismoore/jsrender.git",
-    "basePath": "",
-    "files": [
-      "jsrender*.+(js|map)"
-    ]
-  }
+  "npmName": "jsrender",
+  "npmFileMap": [
+    {
+      "basePath": "",
+      "files": [
+        "jsrender.min*.+(js|map)",
+        "jsrender.js"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
jsrender v0.9.71 can be downloaded from npm package.