### PR TITLE
fix npm auto-update config typo of systemjs

### DIFF
--- a/ajax/libs/systemjs/package.json
+++ b/ajax/libs/systemjs/package.json
@@ -15,9 +15,9 @@
   "npmName": "systemjs",
   "npmFileMap": [
     {
-      "basePath": "/dist",
+      "basePath": "dist",
       "files": [
-        "*/"
+        "**/*"
       ]
     }
   ],


### PR DESCRIPTION
because #6517, i found there is a typo error, so the latest version can't be updated.