### PR TITLE
update license info of libraries #1

### DIFF
--- a/ajax/libs/ScrollMagic/package.json
+++ b/ajax/libs/ScrollMagic/package.json
@@ -9,7 +9,7 @@
   },
   "licenses": [
     "MIT",
-    "GPL-3.0+"
+    "GPL-3.0"
   ],
   "homepage": "http://janpaepke.github.io/ScrollMagic/",
   "keywords": [

--- a/ajax/libs/UAParser.js/package.json
+++ b/ajax/libs/UAParser.js/package.json
@@ -14,10 +14,7 @@
     "cpu"
   ],
   "licenses": [
-    {
-      "type": "GPLv2",
-      "url": "http://www.gnu.org/licenses/gpl-2.0.html"
-    },
+    "GPL-2.0",
     "MIT"
   ],
   "author": "Faisal Salman <fyzlman@gmail.com> (http://faisalman.com)",

--- a/ajax/libs/bootstrap-rtl/package.json
+++ b/ajax/libs/bootstrap-rtl/package.json
@@ -16,10 +16,7 @@
     "hebrew",
     "theme"
   ],
-  "license": {
-    "type": "Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International",
-    "url": "http://creativecommons.org/licenses/by-nc-sa/4.0/"
-  },
+  "license": "Unlicense",
   "repository": {
     "type": "git",
     "url": "https://github.com/morteza/bootstrap-rtl.git"

--- a/ajax/libs/chainvas/package.json
+++ b/ajax/libs/chainvas/package.json
@@ -12,10 +12,7 @@
     "Chainvas",
     "canvas"
   ],
-  "license": {
-    "type": "none",
-    "url": "NA"
-  },
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/LeaVerou/chainvas"

--- a/ajax/libs/classlist/package.json
+++ b/ajax/libs/classlist/package.json
@@ -17,7 +17,5 @@
     "classlist",
     "polyfill"
   ],
-  "license": {
-    "type": "Public Domain"
-  }
+  "license": "Unlicense"
 }

--- a/ajax/libs/crypto-js/package.json
+++ b/ajax/libs/crypto-js/package.json
@@ -21,10 +21,7 @@
   "author": {
     "name": "Jeff Mott"
   },
-  "license": {
-    "type": "New BSD License",
-    "url": "http://opensource.org/licenses/BSD-3-Clause"
-  },
+  "license": "BSD-3-Clause",
   "repository": {
     "type": "svn",
     "url": "http://crypto-js.googlecode.com/svn"

--- a/ajax/libs/d3-geo-projection/package.json
+++ b/ajax/libs/d3-geo-projection/package.json
@@ -27,8 +27,5 @@
       ]
     }
   ],
-  "license": {
-    "type": "BSD",
-    "url": "https://github.com/d3/d3-geo-projection/blob/master/LICENSE"
-  }
+  "license": "BSD-3-Clause"
 }

--- a/ajax/libs/datatables-colvis/package.json
+++ b/ajax/libs/datatables-colvis/package.json
@@ -4,16 +4,7 @@
   "filename": "js/dataTables.colVis.min.js",
   "description": "ColVis adds a button to the toolbars around DataTables which gives the end user of the table the ability to dynamically change the visibility of the columns in the table",
   "homepage": "https://datatables.net/extras/colvis/",
-  "licenses": [
-    {
-      "type": "BSD",
-      "url": "http://datatables.net/license_bsd"
-    },
-    {
-      "type": "GPLv2",
-      "url": "http://datatables.net/license_gpl2"
-    }
-  ],
+  "license": "MIT",
   "dependencies": {
     "jquery": "1.3 - 2.1"
   },

--- a/ajax/libs/datatables-fixedheader/package.json
+++ b/ajax/libs/datatables-fixedheader/package.json
@@ -4,16 +4,7 @@
   "filename": "dataTables.fixedHeader.min.js",
   "description": "The FixedHeader plug-in will freeze in place the header, footer and left and/or right most columns in a DataTable, ensuring that title information will remain always visible.",
   "homepage": "http://datatables.net/extensions/fixedheader/",
-  "licenses": [
-    {
-      "type": "BSD",
-      "url": "http://datatables.net/license_bsd"
-    },
-    {
-      "type": "GPLv2",
-      "url": "http://datatables.net/license_gpl2"
-    }
-  ],
+  "license": "MIT",
   "dependencies": {
     "jquery": "1.3 - 1.7"
   },

--- a/ajax/libs/django.js/package.json
+++ b/ajax/libs/django.js/package.json
@@ -15,8 +15,5 @@
   "dependencies": {
     "jquery": ">=1.8"
   },
-  "license": {
-    "type": "LGPL 3",
-    "url": "http://www.gnu.org/licenses/lgpl-3.0.txt"
-  }
+  "license": "LGPL-3.0"
 }


### PR DESCRIPTION
Hi @maruilian11 

For #5544, I have update the license info of these 10 libraries.
- ScrollMagic　[ref](https://github.com/janpaepke/ScrollMagic/blob/master/LICENSE.md)
- UAParser.js　[ref](https://github.com/faisalman/ua-parser-js#license)
- bootstrap-rtl　[ref](https://github.com/morteza/bootstrap-rtl#license)
- chainvas　[ref](https://github.com/LeaVerou/chainvas/blob/master/chainvas.js#L4)
- classlist　[ref](https://github.com/eligrey/classList.js/blob/master/LICENSE.md#L1)
- crypto-js　[ref](https://code.google.com/p/crypto-js/)
- d3-geo-projection　[ref](https://github.com/d3/d3-geo-projection/blob/master/LICENSE)
- datatables-colvis　[ref](https://github.com/DataTables/ColVis/blob/master/js/dataTables.colVis.js#L15)
- datatables-fixedheader 　[ref](https://github.com/DataTables/FixedHeader/blob/master/License.txt#L1)
- django.js 　[ref](https://github.com/noirbizarre/django.js/blob/master/LICENSE)

Among of them, "bootstrap-rtl" and "classlist" choose to release into `"public domain"`.
So I note their license as `"Unlicense"`, according to this [doc](http://unlicense.org/).

Would you mind checking this PR for me? Thank you~ :-D
