### PR TITLE
update license info of libraries #2

### DIFF
--- a/ajax/libs/datatables-tabletools/package.json
+++ b/ajax/libs/datatables-tabletools/package.json
@@ -4,16 +4,7 @@
   "filename": "js/TableTools.min.js",
   "description": "TableTools is a plug-in for the DataTables HTML table enhancer, which adds a highly customisable button toolbar to a DataTable.",
   "homepage": "http://datatables.net/extras/tabletools/",
-  "licenses": [
-    {
-      "type": "BSD",
-      "url": "http://datatables.net/license_bsd"
-    },
-    {
-      "type": "GPLv2",
-      "url": "http://datatables.net/license_gpl2"
-    }
-  ],
+  "license": "MIT",
   "dependencies": {
     "jquery": "1.3 - 1.7",
     "ZeroClipboard": "1.3 - 1.7"

--- a/ajax/libs/ekko-lightbox/package.json
+++ b/ajax/libs/ekko-lightbox/package.json
@@ -18,10 +18,7 @@
     "type": "git",
     "url": "https://github.com/ashleydw/lightbox.git"
   },
-  "license": {
-    "type": "GNU GENERAL PUBLIC LICENSE",
-    "url": "https://github.com/ashleydw/lightbox/blob/master/LICENSE.txt"
-  },
+  "license": "MIT",
   "npmName": "ekko-lightbox",
   "npmFileMap": [
     {

--- a/ajax/libs/embedly-jquery/package.json
+++ b/ajax/libs/embedly-jquery/package.json
@@ -12,10 +12,7 @@
     "jQuery",
     "embed"
   ],
-  "license": {
-    "type": "BSD",
-    "url": "https://github.com/embedly/embedly-jquery/tree/master/LICENSE/"
-  },
+  "license": "BSD-3-Clause",
   "repository": {
     "type": "git",
     "url": "https://github.com/embedly/embedly-jquery"

--- a/ajax/libs/emojione/package.json
+++ b/ajax/libs/emojione/package.json
@@ -33,10 +33,10 @@
       "lib/js/emojione.min.js"
     ]
   },
-  "license": {
-    "type": "(CC-BY-SA-4.0 and MIT)",
-    "url": "https://github.com/Ranks/emojione/blob/master/LICENSE.md"
-  },
+  "licenses": [
+    "CC-BY-4.0",
+    "MIT"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/Ranks/emojione.git"

--- a/ajax/libs/equalize.js/package.json
+++ b/ajax/libs/equalize.js/package.json
@@ -18,10 +18,7 @@
   },
   "licenses": [
     "MIT",
-    {
-      "type": "GPLv2",
-      "url": "http://opensource.org/licenses/GPL-2.0"
-    }
+    "GPL-2.0"
   ],
   "autoupdate": {
     "source": "git",

--- a/ajax/libs/evil.js/package.json
+++ b/ajax/libs/evil.js/package.json
@@ -9,9 +9,7 @@
     "evil",
     "evil.js"
   ],
-  "license": {
-    "type": "Public Domain"
-  },
+  "license": "Unlicense",
   "repository": {
     "type": "git",
     "url": "https://github.com/kitcambridge/evil.js.git"

--- a/ajax/libs/extjs/package.json
+++ b/ajax/libs/extjs/package.json
@@ -10,18 +10,5 @@
     "desktop",
     "popular"
   ],
-  "licenses": [
-    {
-      "type": "GNU General Public License Version 3",
-      "url": "http://www.gnu.org/licenses/gpl.html"
-    },
-    {
-      "type": "Open Source License Exception for Applications",
-      "url": "http://www.sencha.com/products/floss-exception.php"
-    },
-    {
-      "type": "Open Source License Exception for Development",
-      "url": "http://www.sencha.com/products/ux-exception.php"
-    }
-  ]
+  "license": "GPL-3.0"
 }

--- a/ajax/libs/geoext/package.json
+++ b/ajax/libs/geoext/package.json
@@ -12,10 +12,7 @@
     "openlayers",
     "maps"
   ],
-  "license": {
-    "type": "BSD",
-    "url": "http://trac.geoext.org/wiki/license"
-  },
+  "license": "BSD-3-Clause",
   "repository": {
     "type": "git",
     "url": "https://github.com/geoext/geoext"

--- a/ajax/libs/intercom.js/package.json
+++ b/ajax/libs/intercom.js/package.json
@@ -15,10 +15,7 @@
     "intercom",
     "js"
   ],
-  "license": {
-    "type": "Apache",
-    "url": "http://www.apache.org/licenses/LICENSE-2.0"
-  },
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/diy/intercom.js.git"

--- a/ajax/libs/jQuery.dotdotdot/package.json
+++ b/ajax/libs/jQuery.dotdotdot/package.json
@@ -19,13 +19,7 @@
   "dependencies": {
     "jquery": ">= 1.4.3"
   },
-  "licenses": [
-    "MIT",
-    {
-      "type": "GPL",
-      "url": "http://en.wikipedia.org/wiki/GNU_General_Public_License"
-    }
-  ],
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/BeSite/jQuery.dotdotdot.git"

--- a/ajax/libs/jo/package.json
+++ b/ajax/libs/jo/package.json
@@ -12,8 +12,5 @@
     "type": "git",
     "url": "https://github.com/davebalmer/jo.git"
   },
-  "license": {
-    "type": "Redistribution",
-    "url": "http://joapp.com/docs/#License"
-  }
+  "license": "BSD-2-Clause"
 }


### PR DESCRIPTION
Hi @Piicksarn 

For #5544, I have update the license info of these 11 libraries.
- datatables-tabletools　[ref](https://github.com/DataTables/TableTools/blob/master/License.txt)
- ekko-lightbox　[ref](https://github.com/ashleydw/lightbox/blob/master/LICENSE#L1)
- embedly-jquery　[ref](https://github.com/embedly/embedly-jquery/blob/master/LICENSE)
- emojione　[ref](https://github.com/Ranks/emojione/blob/master/LICENSE.md)
- equalize.js　[ref](https://github.com/tsvensen/equalize.js#legal)
- evil.js　[ref](https://github.com/kitcambridge/evil.js#license)
- extjs　[ref](https://www.sencha.com/legal/GPL/)
- geoext　[ref](http://trac.geoext.org/wiki/license#TheGeoExtLicense)
- intercom.js 　[ref](https://github.com/diy/intercom.js#license)
- jQuery.dotdotdot　[ref](https://github.com/BeSite/jQuery.dotdotdot/blob/master/LICENSE.txt#L1)
- jo　[ref](https://github.com/davebalmer/jo/blob/ec767af487b8653778c36168c7b3a5f478753cc5/LICENSE.mdown#license)

Among of them, "evil.js" choose to release into `"public domain"`.
So I note their license as `"Unlicense"`, according to this [doc](http://unlicense.org/).

Would you mind checking this PR for me? Thank you~ :-D
