### PR TITLE
update license info of libraries #3

### DIFF
--- a/ajax/libs/jqPlot/package.json
+++ b/ajax/libs/jqPlot/package.json
@@ -12,10 +12,7 @@
   ],
   "licenses": [
     "MIT",
-    {
-      "type": "GPL",
-      "url": "http://www.opensource.org/licenses/gpl-license.php"
-    }
+    "GPL-2.0"
   ],
   "repository": {
     "type": "git",

--- a/ajax/libs/jquery-form-validator/package.json
+++ b/ajax/libs/jquery-form-validator/package.json
@@ -34,8 +34,5 @@
       "lang/*.js"
     ]
   },
-  "license": {
-    "type": "Dual licensed under the MIT or GPL Version 2 licenses",
-    "url": "http://www.gnu.org/licenses/gpl-2.0.html"
-  }
+  "license": "MIT"
 }

--- a/ajax/libs/jquery-mockjax/package.json
+++ b/ajax/libs/jquery-mockjax/package.json
@@ -13,10 +13,7 @@
   "homepage": "http://code.appendto.com/plugins/jquery-mockjax/",
   "licenses": [
     "MIT",
-    {
-      "type": "GPLv2",
-      "url": "http://appendto.com/open-source-licenses"
-    }
+    "GPL-2.0"
   ],
   "autoupdate": {
     "source": "git",

--- a/ajax/libs/jquery.blockUI/package.json
+++ b/ajax/libs/jquery.blockUI/package.json
@@ -16,10 +16,7 @@
   },
   "licenses": [
     "MIT",
-    {
-      "type": "GPL",
-      "url": "http://malsup.github.com/gpl-license-v2.txt"
-    }
+    "GPL-2.0"
   ],
   "docs": "http://jquery.malsup.com/block/",
   "download": "http://malsup.github.com/jquery.blockUI.js",

--- a/ajax/libs/jquery.collapsible/package.json
+++ b/ajax/libs/jquery.collapsible/package.json
@@ -13,10 +13,7 @@
     "div"
   ],
   "version": "1.2",
-  "license": {
-    "type": "BSD",
-    "url": "http://www.snyderplace.com/collapsible/license.txt"
-  },
+  "license": "BSD-3-Clause",
   "repository": {
     "type": "git",
     "url": "git://github.juven14/Collapsible.git"

--- a/ajax/libs/jquery.form/package.json
+++ b/ajax/libs/jquery.form/package.json
@@ -15,10 +15,7 @@
   },
   "licenses": [
     "MIT",
-    {
-      "type": "GPL",
-      "url": "http://malsup.github.com/gpl-license-v2.txt"
-    }
+    "GPL-2.0"
   ],
   "homepage": "http://jquery.malsup.com/form/",
   "docs": "http://jquery.malsup.com/form/",

--- a/ajax/libs/jquery.mb.YTPlayer/package.json
+++ b/ajax/libs/jquery.mb.YTPlayer/package.json
@@ -36,5 +36,8 @@
     "type": "git",
     "url": "git://github.com/pupunzi/jquery.mb.YTPlayer.git"
   },
-  "license": "MIT"
+  "licenses": [
+    "MIT",
+    "GPL-2.0"
+  ]
 }

--- a/ajax/libs/machina.js/package.json
+++ b/ajax/libs/machina.js/package.json
@@ -27,10 +27,7 @@
   },
   "licenses": [
     "MIT",
-    {
-      "type": "GPL",
-      "url": "http://opensource.org/licenses/GPL-2.0"
-    }
+    "GPL-2.0"
   ],
   "npmName": "machina",
   "npmFileMap": [

--- a/ajax/libs/mixitup/package.json
+++ b/ajax/libs/mixitup/package.json
@@ -20,10 +20,7 @@
       "jquery.mixitup*.js"
     ]
   },
-  "license": {
-    "type": "Creative Commons Attribution-NoDerivs 3.0 Unported",
-    "url": "http://creativecommons.org/licenses/by-nd/3.0/"
-  },
+  "license": "CC-BY-NC-4.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/patrickkunka/mixitup"

--- a/ajax/libs/placeholder-shiv/package.json
+++ b/ajax/libs/placeholder-shiv/package.json
@@ -12,8 +12,5 @@
     "type": "git",
     "url": "https://github.com/walterdavis/placeholder-shiv.git"
   },
-  "license": {
-    "type": "BSD",
-    "url": "https://github.com/walterdavis/placeholder-shiv/blob/master/LICENSE.txt"
-  }
+  "license": "BSD-3-Clause"
 }


### PR DESCRIPTION
Hi @maruilian11 

For #5544, I have update the license info of these 10 libraries.
- jqPlot　[ref](https://github.com/jqPlot/jqPlot/#legal-notices)
- jquery-form-validator　[ref](http://www.formvalidator.net/#license)
- jquery-mockjax　[ref](https://github.com/jakerella/jquery-mockjax#license)
- jquery.blockUI　[ref](https://github.com/malsup/blockui#copyright-and-license)
- jquery.collapsible　[ref](https://github.com/juven14/Collapsible/blob/master/LICENSE#L1)
- jquery.form　[ref](https://github.com/malsup/form#copyright-and-license)
- jquery.mb.YTPlayer　[ref](https://github.com/pupunzi/jquery.mb.YTPlayer/tree/master/licences)
- machina.js　[ref](https://github.com/ifandelse/machina.js/blob/master/LICENSE)
- mixitup　[ref](https://mixitup.kunkalabs.com/licenses/)
- placeholder-shiv 　[ref](https://github.com/walterdavis/placeholder-shiv/blob/master/LICENSE.txt)

Would you mind checking this PR for me? Thank you~ :-D
