### PR TITLE
modify canvas-nest.js auto-update method to npm

### DIFF
--- a/ajax/libs/canvas-nest.js/package.json
+++ b/ajax/libs/canvas-nest.js/package.json
@@ -9,14 +9,15 @@
     "html5",
     "nest"
   ],
-  "autoupdate": {
-    "source": "git",
-    "target": "git://github.com/aTool-org/canvas-nest.js.git",
-    "basePath": "",
-    "files": [
-      "canvas-nest*.js"
-    ]
-  },
+  "npmName": "canvas-nest.js",
+  "npmFileMap": [
+    {
+      "basePath": "",
+      "files": [
+        "canvas-nest*.js"
+      ]
+    }
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/aTool-org/canvas-nest.js.git"


### PR DESCRIPTION
Hi @Piicksarn

`canvas-nest.js` has been add to project last week(see #6544 ), now need to modify the auto-update method to `npm`, thx

` Watch 9 ` ` Star 156 ` ` Fork 62 `

 - [ ] Not found on cdnjs repo
 - [ ] No already exist issue and PR
 - [x] Notable popularity : Watch 9, Star 156, Fork 62
 - [x] Project has public repository on famous online hosting platform (or been hosted on npm)
 - [x] Has valid tags for each versions (for git auto-update)
 - [x] Auto-update setup
 - [x] Auto-update target/source is valid.
 - [x] Auto-update filemap is correct.