### PR TITLE
Add license info of bitcoinjs-lib, bonsai, bootstrap-social, chaplin with MIT

### DIFF
--- a/ajax/libs/bitcoinjs-lib/package.json
+++ b/ajax/libs/bitcoinjs-lib/package.json
@@ -14,5 +14,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/bitcoinjs/bitcoinjs-lib.git"
-  }
+  },
+  "license": "MIT"
 }

--- a/ajax/libs/bonsai/package.json
+++ b/ajax/libs/bonsai/package.json
@@ -13,5 +13,6 @@
     "type": "git",
     "url": "https://github.com/uxebu/bonsai/"
   },
-  "author": "uxebu Inc. (http://uxebu.com/)"
+  "author": "uxebu Inc. (http://uxebu.com/)",
+  "license": "MIT"
 }

--- a/ajax/libs/bootstrap-social/package.json
+++ b/ajax/libs/bootstrap-social/package.json
@@ -20,5 +20,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/lipis/bootstrap-social"
-  }
+  },
+  "license": "MIT"
 }

--- a/ajax/libs/chaplin/package.json
+++ b/ajax/libs/chaplin/package.json
@@ -9,5 +9,6 @@
       "type": "git",
       "url": "git://github.com/chaplinjs/chaplin.git"
     }
-  ]
+  ],
+  "license": "MIT"
 }


### PR DESCRIPTION
For #6324 

- bitcoinjs-lib [License ref](https://github.com/bitcoinjs/bitcoinjs-lib#license)
- bonsai [License ref](https://github.com/uxebu/bonsai/blob/master/LICENSE)
- bootstrap-social [License ref](https://github.com/lipis/bootstrap-social/blob/gh-pages/LICENSE)
- chaplin [License ref](https://github.com/chaplinjs/chaplin/blob/master/MIT-LICENSE.txt)