### PR TITLE
Enable npm autoupdate for jquery-migrate

### DIFF
--- a/ajax/libs/jquery-migrate/package.json
+++ b/ajax/libs/jquery-migrate/package.json
@@ -1,5 +1,14 @@
 {
   "name": "jquery-migrate",
+  "npmName": "jquery-migrate",
+  "npmFileMap": [
+    {
+      "basePath": "/dist/",
+      "files": [
+        "jquery-migrate.*"
+      ]
+    }
+  ],
   "filename": "jquery-migrate.min.js",
   "version": "1.2.1",
   "description": "Migrate older jQuery code to jQuery 1.9+",


### PR DESCRIPTION
jquery-migrate v1.3.0 has been released a few days ago. So this seems like the perfect time to add autoupdate to this module.