### PR TITLE
Add missing "filename" requirement for autoupdate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@
  
 4. For those libs can use auto-update, you should add [auto-update config](https://github.com/cdnjs/cdnjs#enabling-gitrecommended-or-npm-auto-update) for it, but as the first pull request to add a lib, you should still add its real files, or you won't pass the test.
 
-### d. adding a new library
+### d. Adding a new library
 
 1. Libraries are stored in the ajax/libs directory. Each library has its own subdirectory of ajax/libs and each version of the library has its own subdirectory of the library directory name, for example:
  > /ajax/libs/jquery/2.0.0/
@@ -94,6 +94,7 @@
  * If there is an official `package.json`, please try to follow the official version, the best way is just copy from the official and do a little modification of it.
  * If there is **not** an official `package.json`, please **create** it by yourself, you should refer to [doc of package.json](https://www.npmjs.org/doc/package.json.html) orother lib's `package.json`, and the data should be as close as official data as possible.
   * If you will **create** its `package.json`, the indent of it **must** be `2 spaces`, others will be fine to follow official version or to use 2 spaces.
+  * Please include a `filename` property that points to the main minified file within the cdnjs target directory. If the file is in a subfolder, include it with the filename (e.g. `"filename" : "js/index.js"`).
   * Please use [JSONLint](http://jsonlint.com/) to validate your `package.json`.
 
 3. We use the directory/folder name and `name` property in `package.json` to identify a library, so this two string should be **totally** equal.

--- a/documents/autoupdate.md
+++ b/documents/autoupdate.md
@@ -20,6 +20,7 @@ To add `git` auto-update config to a library, update the `package.json` with con
 To add an `npm` hook to a library, update the `package.json` with configuration details and submit your pull request. An example configuration:
 
 ```js
+  "filename": "function-plot.min.js",
   "npmName": "function-plot",
   "npmFileMap": [
     {
@@ -32,6 +33,7 @@ To add an `npm` hook to a library, update the `package.json` with configuration 
 ```
 
 * Please __don't__ touch `version` number in this step, it'll be automatically updated
+* `filename` must point to a minified file within the cdnjs target directory. If the file is in a subfolder, then include the folder (e.g. `"js/function-plot.min.js"`)
 * `npmName` should map to the name of the library on `npm`
 * `npmFileMap` is a list of files to take from the `npm` tarball and host on cdnjs
 * `basePath` will be ignored when copying over to the CDN
@@ -43,6 +45,7 @@ The above example looks in the tarball whose structure might look like this:
 ```
 |__dist
 | |__function-plot.js
+| |__function-plot.min.js
 |__bower.json
 |__index.js
 |__site.js
@@ -64,6 +67,7 @@ The auto-update process will look for `dist` inside the named tarball and copy a
     |__function-plot
       |__x.y.z
         |__function-plot.js
+        |__function-plot.min.js
 ```
 
 ...where `x.y.z` is the version number, extracted from the `package.json` on npm.

--- a/documents/autoupdate.md
+++ b/documents/autoupdate.md
@@ -5,6 +5,7 @@ cdnjs automatically updates libraries that are known to be hosted on `npm` or gi
 To add `git` auto-update config to a library, update the `package.json` with configuration details and submit your pull request. An example configuration:
 
 ```js
+  "filename": "underscore-min.js",
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/jashkenas/underscore.git",


### PR DESCRIPTION
While performing an `npm test`, I discovered that a `"filename"` property is required for an autoupdate setup:

``` shell
    my-repo
      ✗ my-repo package.json is valid
        » my-repo is not a valid cdnjs package.json format:
          » NPM package.json
                Property is required (true): /properties/filename // valid-packages-test.js:82

      ✗ my-repo: filename from package.json exists
        » ./ajax/libs/my-repo/1.0.0/undefined does not exist but is referenced in package.json! // valid-packages-test.js:101
```
