### PR TITLE
Add BigVideo.js by a single package.json

### DIFF
--- a/ajax/libs/BigVideo.js/package.json
+++ b/ajax/libs/BigVideo.js/package.json
@@ -1,0 +1,25 @@
+{"name": "BigVideo.js",
+"filename": "bigvideo.min.js",
+            "description": "The jQuery Plugin for Big Background Video (and Images)",
+  "keywords": [
+      "video",
+    "background"
+  ],
+  "author"         :         {
+      "name": "John Polacek",
+"url": "http://johnpolacek.com"
+          },
+              "license": "MIT","repository": {"type": "git","url": "https://github.com/dfcb/BigVideo.js"},
+  "autoupdate": {
+            "source"   : "git",
+          "target"     :      "git://github.com/dfcb/BigVideo.js.git",
+        "basePath"     :         "",
+      "files": ["+(css|lib)/bigvideo*"]
+  },
+  "homepage": "https://dfcb.github.com/BigVideo.js/",
+    "dependencies": {
+      "jquery": ">=1.7.2",
+"jqueryui": ">=1.8.22",
+          "videojs":">=3.2.0"  ,  "imagesloaded":">=2.1.1"
+}
+}


### PR DESCRIPTION
This is the first PR since we support adding a library by only a single package.json!

Now you can add a lib by a single package.json, just don't provide the version info in the package.json, and add a valid auto-update confif, so that the lib will be treat as a new library without its real files, and the invalid indent will be also accepted in this situation.

Related commit:
 - allow lib package.json have no version, just ignore that lib
   - https://github.com/cdnjs/cdnjs/commit/b024a698819bd02ad796b45615ed72b25aa5e1d6
 - lib without version info must have valid auto-update config
   - https://github.com/cdnjs/cdnjs/commit/11b89a77eeec7acc2e9343b628a8b6ecff98920d
 - allow wrong indent in lib without real file/version
   - https://github.com/cdnjs/cdnjs/commit/77bbfc1c4b2659491dc374250e8ce128d8088e17
 - allow package.json has no version info
   - https://github.com/cdnjs/autoupdate/commit/d02bd75ea9b27acbdeb21dc2e94f150126a83e28

cc @cdnjs/team-cdnjs 