### PR TITLE
Change mathjs library to npm update script

### DIFF
--- a/ajax/libs/mathjs/package.json
+++ b/ajax/libs/mathjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mathjs",
-  "version": "2.7.0",
+  "version": "3.0.0",
   "filename": "math.min.js",
   "homepage": "http://mathjs.org",
   "description": "Math.js is an extensive math library for JavaScript and Node.js. It features a flexible expression parser and offers an integrated solution to work with numbers, big numbers, complex numbers, units, and matrices.",
@@ -21,13 +21,14 @@
     "matrix",
     "unit"
   ],
-  "autoupdate": {
-    "source": "git",
-    "target": "git://github.com/josdejong/mathjs.git",
-    "basePath": "dist",
-    "files": [
-      "**/*"
-    ]
-  },
+  "npmName": "mathjs",
+  "npmFileMap": [
+    {
+      "basePath": "dist",
+      "files": [
+        "**/*"
+      ]
+    }
+  ],
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
I saw cdnjs hadn't picked up the latest release of mathjs, v3.0.0. 

This PR changes package.json to the preferred npm update script and updates to v3.0.0.

Thanks!