### PR TITLE
Change mathjs library to npm update script

### DIFF
--- a/ajax/libs/mathjs/package.json
+++ b/ajax/libs/mathjs/package.json
@@ -21,13 +21,14 @@
     "matrix",
     "unit"
   ],
-  "autoupdate": {
-    "source": "git",
-    "target": "git://github.com/josdejong/mathjs.git",
-    "basePath": "dist",
-    "files": [
-      "**/*"
-    ]
-  },
+  "npmName": "mathjs",
+  "npmFileMap": [
+    {
+      "basePath": "dist",
+      "files": [
+        "**/*"
+      ]
+    }
+  ],
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
I saw cdnjs hadn't picked up the latest release of mathjs, v3.0.0.

This PR changes package.json to the preferred npm update script. I suppose that after updating the script, cdnjs will auomatically add mathjs v3.0.0.

Thanks!