### PR TITLE
Correct Select2 home page

### DIFF
--- a/ajax/libs/select2/package.json
+++ b/ajax/libs/select2/package.json
@@ -3,7 +3,7 @@
   "filename": "js/select2.min.js",
   "version": "4.0.1",
   "description": "Select2 is a jQuery based replacement for select boxes. It supports searching, remote data sets, and infinite scrolling of results.",
-  "homepage": "http://ivaynberg.github.com/select2/",
+  "homepage": "https://select2.github.io/",
   "keywords": [
     "select",
     "jquery",


### PR DESCRIPTION
The home page for Select2 was switched during the 4.0.0 release to the new location at https://select2.github.io. This finally fixes the homepage link in the `package.json` here, since cdnjs never updated it after it was changed in the NPM package.