### PR TITLE
Remove homepage field for lib boexfi

### DIFF
--- a/ajax/libs/boexfi/package.json
+++ b/ajax/libs/boexfi/package.json
@@ -3,7 +3,6 @@
   "filename": "mijs.js",
   "version": "1.0.0",
   "description": "Some sample files used in the implementation of BoxOpi website.",
-  "homepage": "http://www.boxopi.tk/",
   "keywords": [
     "boxopi",
     "boexfi",


### PR DESCRIPTION
@PeterDaveHello 
cause old homepage url point to wrong website, so i remove the homepage field.