### PR TITLE
add lave.js v1.1.9 with autoupdate config

### DIFF
--- a/ajax/libs/lave/1.1.9/lave.js
+++ b/ajax/libs/lave/1.1.9/lave.js
@@ -1,0 +1,443 @@
+'use strict'
+
+export default function(object, options) {
+  if (!options) options = {}
+
+  var functions = new Set
+  var placeholder = Math.random().toString(36).replace(/../, '_')
+  var functionPattern = RegExp(`${placeholder}(\\d+)`, 'g')
+
+  let cache = new Globals
+  let statements = []
+
+  let expression = getExpression(object)
+  statements.push({type: 'ExpressionStatement', expression})
+
+  let declarations = getDeclarations(statements)
+  if (declarations.length) statements.unshift({
+    type: 'VariableDeclaration',
+    declarations,
+    kind: 'var'
+  })
+
+  switch (options.format || 'expression') {
+    case 'expression':
+      break
+
+    case 'module':
+      statements.push({
+        type: 'ExportDefaultDeclaration',
+        declaration: statements.pop().expression
+      })
+      break
+
+    case 'function':
+      statements.push({
+        type: 'ReturnStatement',
+        argument: statements.pop().expression
+      })
+
+      statements = [{
+        type: 'ExpressionStatement',
+        expression: {
+          type: 'FunctionExpression',
+          params: [],
+          body: {
+            type: 'BlockStatement',
+            body: statements
+          }
+        }
+      }]
+
+      break
+
+    default:
+      throw new Error(`Unsupported format: ${options.format}`)
+  }
+
+  let program = {
+    type: 'Program',
+    body: statements
+  }
+
+  if (!options.generate) return program
+
+  let code = options.generate(program)
+  return code.replace(functionPattern, (_, i) => {
+    return Array.from(functions)[i].toString().replace(/^function |^/, 'function ')
+  })
+
+  function getExpression(value) {
+    if (cache.has(value)) return cache.get(value)
+
+    let node = new Object
+    cache.set(value, node)
+
+    if (Object(value) !== value) {
+      if (value < 0) {
+        node.type = 'UnaryExpression'
+        node.operator = '-'
+        node.argument = getExpression(Math.abs(value))
+        return node
+      }
+
+      node.value = value
+      node.type = 'Literal'
+      return node
+    }
+
+    let prototype = Object.getPrototypeOf(value)
+    let propertyNames = Object.getOwnPropertyNames(value)
+    let properties = new Map(propertyNames.map(name =>
+      [name, Object.getOwnPropertyDescriptor(value, name)]
+    ))
+
+    switch (prototype) {
+      case String.prototype:
+        for (let pair of properties) {
+          properties.delete(pair[0])
+          if (pair[0] == 'length') break
+        } // fallthrough
+
+      case Number.prototype:
+      case Boolean.prototype:
+        node.type = 'CallExpression'
+        node.callee = getExpression(Object)
+        node.arguments = [getExpression(value.valueOf())]
+        break
+
+      case RegExp.prototype:
+        properties.delete('source')
+        properties.delete('global')
+        properties.delete('ignoreCase')
+        properties.delete('multiline')
+        properties.delete('lastIndex')
+
+        node.type = 'Literal'
+        node.value = value
+        break
+
+      case Date.prototype:
+        node.type = 'NewExpression'
+        node.callee = getExpression(Date)
+        node.arguments = [getExpression(value.valueOf())]
+        break
+
+      case Buffer.prototype:
+        for (let pair of properties) {
+          properties.delete(pair[0])
+          if (pair[0] == 'length') break
+        }
+
+        node.type = 'CallExpression'
+        node.callee = getExpression(Buffer)
+        node.arguments = [
+          getExpression(value.toString('base64')),
+          getExpression('base64')
+        ]
+        break
+
+      case Error.prototype:
+      case EvalError.prototype:
+      case RangeError.prototype:
+      case ReferenceError.prototype:
+      case SyntaxError.prototype:
+      case TypeError.prototype:
+      case URIError.prototype:
+        properties.delete('message')
+        properties.delete('stack')
+        node.type = 'NewExpression'
+        node.callee = getExpression(value.constructor)
+        node.arguments = [getExpression(value.message)]
+        break
+
+      case Function.prototype:
+        if (isNativeFunction(value)) {
+          throw new Error('Native code cannot be serialized.')
+        }
+
+        properties.delete('length')
+        properties.delete('name')
+        properties.delete('arguments')
+        properties.delete('caller')
+        if (value.prototype && Object.getOwnPropertyNames(value.prototype).length < 2) {
+          properties.delete('prototype')
+        }
+
+        if (options.generate) {
+          functions.add(value)
+          let index = Array.from(functions).indexOf(value)
+          node.type = 'Identifier'
+          node.name = placeholder + index
+          break
+        }
+
+        node.type = 'CallExpression'
+        node.callee = getExpression(eval)
+        node.arguments = [getExpression(`(${value.toString()})`)]
+        break
+
+      case Array.prototype:
+        node.elements = []
+
+        let length = properties.get('length').value
+        let lastIndex = String(length - 1)
+        if (!length || properties.has(lastIndex)) properties.delete('length')
+
+        for (let property of properties) {
+          if (property[0] != node.elements.length) break
+
+          let element = getExpression(property[1].value)
+          if (element.type) {
+            node.elements.push(element)
+            properties.delete(property[0])
+          }
+
+          else node.elements.push(null)
+        }
+
+        node.type = 'ArrayExpression'
+        break
+
+      case Set.prototype:
+      case WeakSet.prototype:
+        let members = Array.from(value)
+        let index = 0
+
+        for (let member of members) {
+          let element = getExpression(member)
+          if (element.type) index++
+          else break
+        }
+
+        node.type = 'NewExpression'
+        node.callee = getExpression(value.constructor)
+        node.arguments = []
+        if (index > 0) {
+          node.arguments.push(getExpression(members.slice(0, index)))
+        }
+
+        for (let member of members.slice(index)) {
+          statements.push({
+            type: 'ExpressionStatement',
+            expression: {
+              type: 'CallExpression',
+              callee: {
+                type: 'MemberExpression',
+                object: node,
+                computed: false,
+                property: {type: 'Identifier', name: 'add'}
+              },
+              arguments: [getExpression(member)]
+            }
+          })
+        }
+        break
+
+      case Map.prototype:
+      case WeakMap.prototype:
+        let entries = Array.from(value)
+
+        for (let entry of entries) {
+          let element = getExpression(entry[1])
+          if (!element.type) {
+            entry.pop()
+            statements.push({
+              type: 'ExpressionStatement',
+              expression: {
+                type: 'CallExpression',
+                callee: {
+                  type: 'MemberExpression',
+                  object: node,
+                  computed: false,
+                  property: {type: 'Identifier', name: 'set'}
+                },
+                arguments: [getExpression(entry[0]), element]
+              }
+            })
+          }
+        }
+
+        node.arguments = [getExpression(entries)]
+        node.callee = getExpression(value.constructor)
+        node.type = 'NewExpression'
+        break
+
+      case Object.prototype:
+        node.properties = []
+        for (let property of properties) {
+          let element = getExpression(property[1].value)
+
+          if (!element.type) {
+            node.properties.push({
+              type: 'Property',
+              key: getExpression(property[0]),
+              value: getExpression(null)
+            })
+            continue
+          }
+
+          properties.delete(property[0])
+          node.properties.push({
+            type: 'Property',
+            key: getExpression(property[0]),
+            value: getExpression(property[1].value)
+          })
+        }
+
+        node.type = 'ObjectExpression'
+        break
+
+      default:
+        node.type = 'CallExpression'
+        node.callee = getExpression(Object.create)
+        node.arguments = [getExpression(prototype)]
+        break
+
+    }
+
+    for (let property of properties) {
+      statements.push({
+        type: 'ExpressionStatement',
+        expression: {
+          type: 'AssignmentExpression',
+          operator: '=',
+          left: {
+            type: 'MemberExpression',
+            object: node,
+            computed: !isNaN(property[0]),
+            property: {type:
+              'Identifier',
+              name: property[0]
+            }
+          },
+          right: getExpression(property[1].value)
+        }
+      })
+    }
+
+    return node
+  }
+
+  function getDeclarations(statements) {
+    let sites = function crawl(sites, object, key, value) {
+      if (Object(value) !== value) return
+      if (value.type == 'Identifier') return
+      if (value.type == 'Literal') return
+
+      let valueSites = sites.get(value)
+      if (valueSites) return valueSites.push({object, key})
+
+      sites.set(value, [{object, key}])
+
+      for (let property in value) {
+        crawl(sites, value, property, value[property])
+      }
+
+      return sites
+    }(new Map, {'': statements}, '', statements)
+
+    let declarations = []
+    for (let entry of sites) {
+      if (entry[1].length < 2) continue
+
+      let id = {type: 'Identifier'}
+      for (let site of entry[1]) site.object[site.key] = id
+
+      declarations.push({
+        type: 'VariableDeclarator',
+        id,
+        init: entry[0]
+      })
+    }
+
+    declarations.sort((a, b) => has(a.init, b.id) - has(b.init, a.id))
+
+    let ids = new Identifiers
+    for (let declaration of declarations) declaration.id.name = ids.next()
+
+    return declarations
+  }
+}
+
+class Identifiers {
+  constructor() { this.id = 0 }
+  next() {
+    let id = (this.id++).toString(36)
+    try { Function(`var ${id}`); return id }
+    catch (e) { return this.next() }
+  }
+}
+
+function has(parent, child) {
+  if (parent === child) return true
+
+  if (Object(parent) !== parent) return false
+
+  for (let key in parent) {
+    if (has(parent[key], child)) return true
+  }
+
+  return false
+}
+
+let nativeCode = String(Object).match(/{.*/)[0]
+function isNativeFunction(fn) {
+  let source = String(fn)
+  let index = source.indexOf(nativeCode)
+  if (index < 0) return false
+
+  let length = index + nativeCode.length
+  return length === source.length
+}
+
+function Globals() {
+  let globals = new Map([
+    [NaN, {type: 'Identifier', name: 'NaN'}],
+    [null, {type: 'Literal', value: null}],
+    [undefined, {type: 'Identifier', name: 'undefined'}],
+    [Infinity, {type: 'Identifier', name: 'Infinity'}],
+    [(0,eval)('this'), {
+      type: 'CallExpression',
+      callee: {
+        type: 'SequenceExpression',
+        expressions: [
+          {type: 'Literal', value: 0},
+          {type: 'Identifier', name: 'eval'}
+        ]
+      },
+      "arguments": [{type: 'Literal', value: 'this'}]
+    }]
+  ])
+
+  return crawl(globals, (0, eval)('this'))
+}
+
+const STANDARD_GLOBALS = require('vm')
+  .runInNewContext('Object.getOwnPropertyNames(this)')
+  .concat('Buffer')
+
+function crawl(map, value, object) {
+  let names = object ? Object.getOwnPropertyNames(value) : STANDARD_GLOBALS
+  let properties = []
+
+  for (let name of names) {
+    let descriptor = Object.getOwnPropertyDescriptor(value, name)
+
+    if (Object(descriptor.value) !== descriptor.value) continue
+    if (map.has(descriptor.value)) continue
+
+    let property = {type: 'Identifier', name}
+    if (object) property = {type: 'MemberExpression', object, property}
+
+    map.set(descriptor.value, property)
+
+    properties.push({value: descriptor.value, object: property})
+  }
+
+  for (let property of properties) {
+    crawl(map, property.value, property.object)
+  }
+
+  return map
+}

--- a/ajax/libs/lave/package.json
+++ b/ajax/libs/lave/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "lave",
+  "filename": "lave.js",
+  "version": "1.1.9",
+  "description": "eval in reverse: stringifying all the stuff that JSON.stringify won't",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jed/lave.git"
+  },
+  "keywords": [
+    "stringify",
+    "uneval",
+    "circular",
+    "json",
+    "serialize"
+  ],
+  "license": "MIT",
+  "npmName": "lave",
+  "npmFileMap": [
+    {
+      "basePath": "",
+      "files": [
+        "lave*"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Checklist for **Pull request** or **lib adding request issue** follows the conventions.

Note that if you are using a distribution purpose repository/package, please also provide the url and other related info like popularity of the source code repo/package.

# Profile of the lib
 * Git repository (required): https://github.com/jed/lave
 * Official website (optional, not the repository): 
 * NPM package url (optional): https://www.npmjs.com/package/lave
 * GitHub / Bitbucket popularity (required):
   - Count of stars: 785
   - Count of watchers: 17
   - Count of forks: 17
 * NPM download stats (optional):
   - Downloads in the last day: 27
   - Downloads in the last week: 77
   - Downloads in the last month: 740

# Essential checklist
 * [ ] I'm the author of this library
   * [ ] I would like to add link to the page of this library on CDNJS on website / readme
 * [x] This lib was not found on cdnjs repo
 * [x] No already exist / duplicated issue and PR
 * [x] The lib has notable popularity
   * [x] More than 100 [Stars / Watchers / Forks] on [GitHub / Bitbucket]
   * [x] More than 500 downloads stats per month on npm registry
 * [x] Project has public repository on famous online hosting platform (or been hosted on npm)

# Auto-update checklist
 * [ ] Has valid tags for each versions (for git auto-update)
 * [x] Auto-update setup
 * [x] Auto-update target/source is valid.
 * [x] Auto-update filemap is correct.

# Git commit checklist
 * [x] The first line of commit message is less then 50 chars, be clean and clear, easy to understand.
 * [x] The parent of the commit(s) in the PR is not old than 3 days.
 * [x] Pull request is sending from a non-master branch with meaningful name.
 * [x] Separate unrelated changes into different commits.
 * [x] Use rebase to squash/fixup dummy/unnecessary commits into only one commit.
 * [x] Close corresponding issue in commit message
 * [x] Mention related issue(s), people in commit message, comment.

close #7323, cc @jed