### PR TITLE
Update Shaka Player paths in preparation for v2.0

### DIFF
--- a/ajax/libs/shaka-player/package.json
+++ b/ajax/libs/shaka-player/package.json
@@ -13,11 +13,9 @@
   "npmName": "shaka-player",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "/dist/",
       "files": [
-        "shaka-player.compiled.js",
-        "shaka-player.vod.js",
-        "shaka-player.live.js"
+        "shaka-player.compiled.js"
       ]
     }
   ]


### PR DESCRIPTION
Shaka Player v2.0 only distributes one file, and it has moved to /dist/.

# Profile of the lib
 * Git repository (required): https://github.com/google/shaka-player
 * NPM package url (optional): https://www.npmjs.com/package/shaka-player
 * GitHub / Bitbucket popularity (required):
   - Count of stars: 544
   - Count of watchers: 104
   - Count of forks: 118
 * NPM download stats (optional):
   - Downloads in the last day: 34
   - Downloads in the last week: 185
   - Downloads in the last month: 1089

# Essential checklist
 * [X] I'm the author of this library
 * [X] Project has public repository on famous online hosting platform (or been hosted on npm)