### PR TITLE
Update update.json of free-jqgrid

### DIFF
--- a/ajax/libs/free-jqgrid/package.json
+++ b/ajax/libs/free-jqgrid/package.json
@@ -6,11 +6,9 @@
       "basePath": "/",
       "files": [
         "css/*",
-        "js/jquery.jqgrid.min.js",
-        "js/jquery.jqgrid.min.map",
-        "js/jquery.jqgrid.src.js",
-        "js/i18n/*.js",
-        "js/i18n/*.map",
+        "js/*",
+        "js/i18n/*",
+        "js/min/*",
         "plugins/*"
       ]
     }


### PR DESCRIPTION
Update `package.json` of free jqGrid (GitHub repository: [here](https://github.com/free-jqgrid/jqGrid), NPM package: [here](https://www.npmjs.com/package/free-jqgrid)).

Fix the structure of directories to better support of JavaScript modules together with the old format, where all module where merged together. One can get advantage of HTTP/2 recently installed on cdnjs.

Thanks in advance!