### PR TITLE
add missing repository info for some libs

### DIFF
--- a/ajax/libs/Backbone.dualStorage/package.json
+++ b/ajax/libs/Backbone.dualStorage/package.json
@@ -27,5 +27,9 @@
     "files": [
       "backbone.dualstorage*.+(js|map)"
     ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/nilbus/Backbone.dualStorage.git"
   }
 }

--- a/ajax/libs/angular-mousewheel/package.json
+++ b/ajax/libs/angular-mousewheel/package.json
@@ -20,5 +20,9 @@
     "files": [
       "mousewheel*"
     ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/monospaced/angular-mousewheel.git"
   }
 }

--- a/ajax/libs/guards/package.json
+++ b/ajax/libs/guards/package.json
@@ -26,5 +26,9 @@
     "files": [
       "guards*"
     ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/on-site/guards.js.git"
   }
 }

--- a/ajax/libs/ion.calendar/package.json
+++ b/ajax/libs/ion.calendar/package.json
@@ -32,5 +32,9 @@
       "js/moment-with-locales*",
       "css/ion.calendar*"
     ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/IonDen/ion.calendar.git"
   }
 }

--- a/ajax/libs/jarallax/package.json
+++ b/ajax/libs/jarallax/package.json
@@ -21,5 +21,9 @@
       "**/*"
     ]
   },
-  "author": "_nK <nkdevinfo@gmail.com>"
+  "author": "_nK <nkdevinfo@gmail.com>",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/nk-o/jarallax.git"
+  }
 }

--- a/ajax/libs/jquery-dotimeout/package.json
+++ b/ajax/libs/jquery-dotimeout/package.json
@@ -21,5 +21,9 @@
     "files": [
       "jquery.ba-dotimeout*.js"
     ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/cowboy/jquery-dotimeout.git"
   }
 }

--- a/ajax/libs/jvectormap/package.json
+++ b/ajax/libs/jvectormap/package.json
@@ -36,5 +36,9 @@
     "files": [
       "jquery-jvectormap*.+(css|js)"
     ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/bjornd/jvectormap.git"
   }
 }

--- a/ajax/libs/min/package.json
+++ b/ajax/libs/min/package.json
@@ -21,5 +21,9 @@
     "files": [
       "entireframework.min.css"
     ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/owenversteeg/min.git"
   }
 }

--- a/ajax/libs/minimap/package.json
+++ b/ajax/libs/minimap/package.json
@@ -26,5 +26,9 @@
     "files": [
       "**/*"
     ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/princejwesley/minimap.git"
   }
 }

--- a/ajax/libs/ng-currency/package.json
+++ b/ajax/libs/ng-currency/package.json
@@ -23,5 +23,9 @@
     "files": [
       "**/*"
     ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/aguirrel/ng-currency.git"
   }
 }

--- a/ajax/libs/switchy.js/package.json
+++ b/ajax/libs/switchy.js/package.json
@@ -27,5 +27,9 @@
       "switchy*.+(css|js|map)"
     ]
   },
-  "license": "WTFPL"
+  "license": "WTFPL",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/lou/switchy.git"
+  }
 }

--- a/ajax/libs/typeahead-addresspicker/package.json
+++ b/ajax/libs/typeahead-addresspicker/package.json
@@ -20,5 +20,9 @@
     "files": [
       "**/*"
     ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/sgruhier/typeahead-addresspicker.git"
   }
 }

--- a/ajax/libs/vue-google-maps/package.json
+++ b/ajax/libs/vue-google-maps/package.json
@@ -15,5 +15,9 @@
     "files": [
       "**/*"
     ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/GuillaumeLeclerc/vue-google-maps.git"
   }
 }


### PR DESCRIPTION
repository info from target of git auto-update.

Affected 13 libs as follow:

- Backbone.dualStorage
- angular-mousewheel
- guards
- ion.calendar
- jarallax
- jquery-dotimeout
- jvectormap
- min
- minimap
- ng-currency
- switchy.js
- typeahead-addresspicker
- vue-google-maps

cc @PeterDaveHello 