### PR TITLE
Update file structure of UPB package

### DIFF
--- a/ajax/libs/upb/package.json
+++ b/ajax/libs/upb/package.json
@@ -19,20 +19,13 @@
   "npmName": "upb",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "lib",
       "files": [
-        "upb.js"
-      ]
-    },
-    {
-      "basePath": "/dist/",
-      "files": [
-        ".js",
-        ".map"
+        "index.js"
       ]
     }
   ],
-  "filename": "upb.min.js",
+  "filename": "upb.js",
   "namespace": "upb",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I am the author of this library. In the most recent version I moved from a `dist` folder to `lib` folder. There are no dependencies to compile, so it works fine. This pull fixes the auto-update to reflect the structure change.