### PR TITLE
Create issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,16 @@
+Add this as a subject: [Request] Add _library name_ 
+
+**Library name:** 
+**Git repository url:**
+**npm package url(optional):** 
+**License(s):**
+**Official homepage:**
+**Wanna say something? Leave message here:**
+
+=====================
+Notes from cdnjs maintainer:
+Please read the README.md and CONTRIBUTING.md document first.
+
+You are welcome to add a library via sending pull request,
+it'll be faster then just opening a request issue,
+and please don't forget to read the guidelines for contributing, thanks!!

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,1 +1,1 @@
-Note: If you'd like to request a new library, please follow [this link](https://cdnjs.com/request-new-lib)!
+Note: If you'd like to request a new library, please follow this link: https://cdnjs.com/request-new-lib

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,16 +1,1 @@
-Add this as a subject: [Request] Add _library name_ 
-
-**Library name:** 
-**Git repository url:**
-**npm package url(optional):** 
-**License(s):**
-**Official homepage:**
-**Wanna say something? Leave message here:**
-
-=====================
-Notes from cdnjs maintainer:
-Please read the README.md and CONTRIBUTING.md document first.
-
-You are welcome to add a library via sending pull request,
-it'll be faster then just opening a request issue,
-and please don't forget to read the guidelines for contributing, thanks!!
+Note: If you'd like to request a new library, please follow [this link](https://cdnjs.com/request-new-lib)!


### PR DESCRIPTION
When clicking the "Request a lib" button on the website you will be redirected [to this URL](https://github.com/cdnjs/cdnjs/issues/new?title=%5BRequest%5D%20Add%20_library_name_%20&body=**Library%20name%3A**%20%0A**Git%20repository%20url%3A**%0A**npm%20package%20url(optional)%3A**%20%0A**License(s)%3A**%0A**Official%20homepage%3A**%0A**Wanna%20say%20something?%20Leave%20message%20here%3A**%0A%0A=====================%0ANotes%20from%20cdnjs%20maintainer%3A%0APlease%20read%20the%20README.md%20and%20CONTRIBUTING.md%20document%20first.%0A%0AYou%20are%20welcome%20to%20add%20a%20library%20via%20sending%20pull%20request%2C%0Ait%27ll%20be%20faster%20then%20just%20opening%20a%20request%20issue%2C%0Aand%20please%20don%27t%20forget%20to%20read%20the%20guidelines%20for%20contributing%2C%20thanks!!). The issue message will be automatically filled. However, when creating a new issue directly from within GitHub, no issue message will be shown. This is solved with this template.