### PR TITLE
Update package.json of Chart.js

### DIFF
--- a/ajax/libs/Chart.js/package.json
+++ b/ajax/libs/Chart.js/package.json
@@ -13,7 +13,7 @@
     {
       "basePath": "dist",
       "files": [
-        "*.js"
+        "**/*"
       ]
     }
   ],

--- a/ajax/libs/Chart.js/package.json
+++ b/ajax/libs/Chart.js/package.json
@@ -9,12 +9,14 @@
   "homepage": "http://www.chartjs.org",
   "author": "nnnick",
   "npmName": "chart.js",
-  "npmFileMap": [{
-    "basePath": "dist",
-    "files": [
-      "*.js"
-    ]
-  }],
+  "npmFileMap": [
+    {
+      "basePath": "dist",
+      "files": [
+        "*.js"
+      ]
+    }
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/chartjs/Chart.js.git"

--- a/ajax/libs/Chart.js/package.json
+++ b/ajax/libs/Chart.js/package.json
@@ -8,20 +8,16 @@
   ],
   "homepage": "http://www.chartjs.org",
   "author": "nnnick",
-  "autoupdate": {
-    "source": "git",
-    "target": "git://github.com/nnnick/Chart.js.git",
-    "basePath": "dist/",
+  "npmName": "chart.js",
+  "npmFileMap": [{
+    "basePath": "dist",
     "files": [
-      "Chart.bundle.js",
-      "Chart.bundle.min.js",
-      "Chart.min.js",
-      "Chart.js"
+      "*.js"
     ]
-  },
+  }],
   "repository": {
     "type": "git",
-    "url": "https://github.com/nnnick/Chart.js.git"
+    "url": "https://github.com/chartjs/Chart.js.git"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
Updating the Chart.js `package.json` to now npm auto update. Starting [this commit](https://github.com/chartjs/Chart.js/commit/9082507c1ccdbe1975519f49071d7e441de2a56d), dist files have been removed from the repository. See https://github.com/chartjs/Chart.js/pull/2555 for details.
