### PR TITLE
Update sparse checkout doc to link original doc.

### DIFF
--- a/sparseCheckout.md
+++ b/sparseCheckout.md
@@ -1,1 +1,3 @@
-documents/sparseCheckout.md
+Goto documents/sparseCheckout.md for sparse checkout and shallow clone details.
+
+Here's the link : https://github.com/cdnjs/cdnjs/blob/master/documents/sparseCheckout.md


### PR DESCRIPTION
The content was not very self explanative. I added link to the original documentation on sparse checkout.