### PR TITLE
fixed auto-update can't update some libs

### DIFF
--- a/ajax/libs/cloudinary-core/package.json
+++ b/ajax/libs/cloudinary-core/package.json
@@ -53,7 +53,7 @@
   "npmName": "cloudinary-core",
   "npmFileMap": [
     {
-      "basePath": ".",
+      "basePath": "",
       "files": [
         "cloudinary-core*"
       ]

--- a/ajax/libs/cloudinary-jquery-file-upload/package.json
+++ b/ajax/libs/cloudinary-jquery-file-upload/package.json
@@ -54,7 +54,7 @@
   "npmName": "cloudinary-jquery-file-upload",
   "npmFileMap": [
     {
-      "basePath": ".",
+      "basePath": "",
       "files": [
         "cloudinary-jquery-file-upload*"
       ]


### PR DESCRIPTION
PR for #8512 
Because the basePath of `cloudinary-jquery-file-upload` and `cloudinary-core` is ```"."```, I modified `"."` to `""` and it can work.
@x09326 Please help me review this pull request, thank you.

close #8512 