### PR TITLE
Enrich HTML5-History-API's package.json(field:license)

### DIFF
--- a/ajax/libs/html5-history-api/package.json
+++ b/ajax/libs/html5-history-api/package.json
@@ -30,7 +30,6 @@
     "url": "git://github.com/devote/HTML5-History-API.git"
   },
   "licenses": [
-    "GPL-3.0",
     "MIT"
   ],
   "author": "Dmitrii Pakhtinov"


### PR DESCRIPTION
#5500

license link:
1. [https://github.com/devote/HTML5-History-API/blob/master/package.json](https://github.com/devote/HTML5-History-API/blob/master/package.json)
2. [https://github.com/devote/HTML5-History-API/blob/master/LICENSE-MIT](https://github.com/devote/HTML5-History-API/blob/master/LICENSE-MIT)
3. [https://github.com/devote/HTML5-History-API/commit/825d10706749e918a15c388e435365340743bf93](https://github.com/devote/HTML5-History-API/commit/825d10706749e918a15c388e435365340743bf93)
