### PR TITLE
transfer jquery.tablesorter to npm auto-update

### DIFF
--- a/ajax/libs/jquery.tablesorter/package.json
+++ b/ajax/libs/jquery.tablesorter/package.json
@@ -31,12 +31,13 @@
     "type": "git",
     "url": "https://github.com/Mottie/tablesorter.git"
   },
-  "autoupdate": {
-    "source": "git",
-    "target": "git://github.com/Mottie/tablesorter.git",
-    "basePath": "dist",
-    "files": [
-      "**/*"
-    ]
-  }
+  "npmName": "tablesorter",
+  "npmFileMap": [
+    {
+      "basePath": "dist",
+      "files": [
+        "**/!(*.less)"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
npm auto-update is faster, however just found that jquery.tablesorter uses different file format between git repo and npm package, in git repo, the dist files use unix format, but in npm pacakge, the files use windows/dos format, which is strange, no matter you use sha256 or md5 to hash the files, you'll get different result from two different sources, so we need this problem been solved first, then we can transfer this lib to npm auto-update.

cc @cdnjs/intern2 
