### PR TITLE
remove leading and trailing slash in auto-update basePath

### DIFF
--- a/ajax/libs/16pixels/package.json
+++ b/ajax/libs/16pixels/package.json
@@ -10,7 +10,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/englishextra/16pixels.git",
-    "basePath": "css/",
+    "basePath": "css",
     "files": [
       "16pixels*"
     ]

--- a/ajax/libs/AniJS/package.json
+++ b/ajax/libs/AniJS/package.json
@@ -20,7 +20,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/anijs/anijs.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "**/*"
     ]

--- a/ajax/libs/Base64/package.json
+++ b/ajax/libs/Base64/package.json
@@ -11,7 +11,7 @@
   "npmName": "Base64",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/Colors.js/package.json
+++ b/ajax/libs/Colors.js/package.json
@@ -14,7 +14,7 @@
   "npmName": "colors.js",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "*.min.js"
       ]

--- a/ajax/libs/Cookies.js/package.json
+++ b/ajax/libs/Cookies.js/package.json
@@ -10,7 +10,7 @@
   "npmName": "cookies-js",
   "npmFileMap": [
     {
-      "basePath": "/src/",
+      "basePath": "src",
       "files": [
         "cookies.js",
         "cookies.min.js"

--- a/ajax/libs/Director/package.json
+++ b/ajax/libs/Director/package.json
@@ -3,7 +3,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/flatiron/director.git",
-    "basePath": "/build/",
+    "basePath": "build",
     "files": [
       "director.min.js",
       "director.js"

--- a/ajax/libs/Han/package.json
+++ b/ajax/libs/Han/package.json
@@ -6,7 +6,7 @@
   "npmName": "han-css",
   "npmFileMap": [
     {
-      "basePath": "dist/",
+      "basePath": "dist",
       "files": [
         "han.min.css",
         "han.css",

--- a/ajax/libs/ICanHaz.js/package.json
+++ b/ajax/libs/ICanHaz.js/package.json
@@ -13,7 +13,7 @@
   "npmName": "icanhaz",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "ICanHaz.min.js"
       ]

--- a/ajax/libs/Ladda/package.json
+++ b/ajax/libs/Ladda/package.json
@@ -3,7 +3,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/hakimel/Ladda.git",
-    "basePath": "/dist/",
+    "basePath": "dist",
     "files": [
       "ladda-themeless.min.css",
       "ladda.jquery.min.js",

--- a/ajax/libs/Leaflet.awesome-markers/package.json
+++ b/ajax/libs/Leaflet.awesome-markers/package.json
@@ -7,7 +7,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/lvoogdt/Leaflet.awesome-markers.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "**/*"
     ]

--- a/ajax/libs/PikaChoose/package.json
+++ b/ajax/libs/PikaChoose/package.json
@@ -19,7 +19,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/jeremyfry/PikaChoose.git",
-    "basePath": "lib/",
+    "basePath": "lib",
     "files": [
       "jquery.pikachoose*.js"
     ]

--- a/ajax/libs/SVG-Morpheus/package.json
+++ b/ajax/libs/SVG-Morpheus/package.json
@@ -21,7 +21,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/alexk111/SVG-Morpheus.git",
-    "basePath": "compile/minified/",
+    "basePath": "compile/minified",
     "files": [
       "*"
     ]

--- a/ajax/libs/ScrollMagic/package.json
+++ b/ajax/libs/ScrollMagic/package.json
@@ -36,13 +36,13 @@
   "npmName": "scrollmagic",
   "npmFileMap": [
     {
-      "basePath": "/scrollmagic/minified/",
+      "basePath": "scrollmagic/minified",
       "files": [
         "**/*.js"
       ]
     },
     {
-      "basePath": "/scrollmagic/uncompressed/",
+      "basePath": "scrollmagic/uncompressed",
       "files": [
         "**/*.js"
       ]

--- a/ajax/libs/Swiper/package.json
+++ b/ajax/libs/Swiper/package.json
@@ -16,7 +16,7 @@
   "npmName": "swiper",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "**/*"
       ]

--- a/ajax/libs/UAParser.js/package.json
+++ b/ajax/libs/UAParser.js/package.json
@@ -23,7 +23,7 @@
   "npmName": "ua-parser-js",
   "npmFileMap": [
     {
-      "basePath": "/src/",
+      "basePath": "src",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/absurd/package.json
+++ b/ajax/libs/absurd/package.json
@@ -11,7 +11,7 @@
   "npmName": "absurd",
   "npmFileMap": [
     {
-      "basePath": "/client-side/build/",
+      "basePath": "client-side/build",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/accounting.js/package.json
+++ b/ajax/libs/accounting.js/package.json
@@ -14,7 +14,7 @@
   "npmName": "accounting",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "accounting.min.js",
         "accounting.js"

--- a/ajax/libs/ajile/package.json
+++ b/ajax/libs/ajile/package.json
@@ -33,7 +33,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/iskitz/ajile.git",
-    "basePath": "/use/",
+    "basePath": "use",
     "files": [
       "com.iskitz.ajile.src.js",
       "com.iskitz.ajile.js",

--- a/ajax/libs/alasql/package.json
+++ b/ajax/libs/alasql/package.json
@@ -37,7 +37,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/agershun/alasql.git",
-    "basePath": "/dist/",
+    "basePath": "dist",
     "files": [
       "alasql-worker.min.js",
       "alasql.min.js"

--- a/ajax/libs/algoliasearch/package.json
+++ b/ajax/libs/algoliasearch/package.json
@@ -14,7 +14,7 @@
   "npmName": "algoliasearch",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/allow-me/package.json
+++ b/ajax/libs/allow-me/package.json
@@ -15,7 +15,7 @@
   "npmName": "allow-me",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js",
         "*.css"

--- a/ajax/libs/ally.js/package.json
+++ b/ajax/libs/ally.js/package.json
@@ -6,7 +6,7 @@
   "npmName": "ally.js",
   "npmFileMap": [
     {
-      "basePath": "./",
+      "basePath": "",
       "files": [
         "ally.min.js",
         "ally.min.js.map"

--- a/ajax/libs/analytics.js/package.json
+++ b/ajax/libs/analytics.js/package.json
@@ -4,7 +4,7 @@
   "npmName": "analytics.js",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "analytics.min.js",
         "analytics.js"

--- a/ajax/libs/angular-autofields/package.json
+++ b/ajax/libs/angular-autofields/package.json
@@ -19,7 +19,7 @@
   "npmName": "angular-autoFields-bootstrap",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "**/*.js"
       ]

--- a/ajax/libs/angular-azure-mobile-service/package.json
+++ b/ajax/libs/angular-azure-mobile-service/package.json
@@ -22,7 +22,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/TerryMooreII/angular-azure-mobile-service.git",
-    "basePath": "/dist/",
+    "basePath": "dist",
     "files": [
       "angular-azure-mobile-service.js",
       "angular-azure-mobile-service.min.js"

--- a/ajax/libs/angular-busy/package.json
+++ b/ajax/libs/angular-busy/package.json
@@ -20,7 +20,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/cgross/angular-busy.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "angular-busy.js",
       "angular-busy.min.js",

--- a/ajax/libs/angular-cache/package.json
+++ b/ajax/libs/angular-cache/package.json
@@ -16,7 +16,7 @@
   "npmName": "angular-cache",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js",
         "*.map"

--- a/ajax/libs/angular-css/package.json
+++ b/ajax/libs/angular-css/package.json
@@ -11,7 +11,7 @@
   "npmName": "angular-css",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/angular-data/package.json
+++ b/ajax/libs/angular-data/package.json
@@ -21,7 +21,7 @@
   "npmName": "angular-data",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js",
         "*.map"

--- a/ajax/libs/angular-dialog-service/package.json
+++ b/ajax/libs/angular-dialog-service/package.json
@@ -13,7 +13,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/m-e-conroy/angular-dialog-service.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "**/*"
     ]

--- a/ajax/libs/angular-filter/package.json
+++ b/ajax/libs/angular-filter/package.json
@@ -20,7 +20,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/a8m/angular-filter.git",
-    "basePath": "/dist/",
+    "basePath": "dist",
     "files": [
       "*.js"
     ]

--- a/ajax/libs/angular-formly-templates-bootstrap/package.json
+++ b/ajax/libs/angular-formly-templates-bootstrap/package.json
@@ -11,7 +11,7 @@
   "npmName": "angular-formly-templates-bootstrap",
   "npmFileMap": [
     {
-      "basePath": "/dist",
+      "basePath": "dist",
       "files": [
         "*"
       ]

--- a/ajax/libs/angular-formly/package.json
+++ b/ajax/libs/angular-formly/package.json
@@ -15,7 +15,7 @@
   "npmName": "angular-formly",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js",
         "*.map"

--- a/ajax/libs/angular-gravatar/package.json
+++ b/ajax/libs/angular-gravatar/package.json
@@ -19,7 +19,7 @@
   "npmName": "angular-gravatar",
   "npmFileMap": [
     {
-      "basePath": "/build",
+      "basePath": "build",
       "files": [
         "**/*"
       ]

--- a/ajax/libs/angular-highlightjs/package.json
+++ b/ajax/libs/angular-highlightjs/package.json
@@ -18,7 +18,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/pc035860/angular-highlightjs.git",
-    "basePath": "build/",
+    "basePath": "build",
     "files": [
       "*.js"
     ]

--- a/ajax/libs/angular-i18n/package.json
+++ b/ajax/libs/angular-i18n/package.json
@@ -14,7 +14,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/angular/angular.js.git",
-    "basePath": "src/ngLocale/",
+    "basePath": "src/ngLocale",
     "files": [
       "angular-locale_*.js"
     ]

--- a/ajax/libs/angular-leaflet-directive/package.json
+++ b/ajax/libs/angular-leaflet-directive/package.json
@@ -18,7 +18,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/tombatossals/angular-leaflet-directive.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "*"
     ]

--- a/ajax/libs/angular-local-storage/package.json
+++ b/ajax/libs/angular-local-storage/package.json
@@ -17,7 +17,7 @@
   "npmName": "angular-local-storage",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/angular-material-icons/package.json
+++ b/ajax/libs/angular-material-icons/package.json
@@ -28,7 +28,7 @@
   "npmName": "angular-material-icons",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "angular-material-icons.min.js"
       ]

--- a/ajax/libs/angular-material/package.json
+++ b/ajax/libs/angular-material/package.json
@@ -12,7 +12,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/angular/bower-material.git",
-    "basePath": "/",
+    "basePath": "",
     "files": [
       "angular-material.*"
     ]

--- a/ajax/libs/angular-materialize/package.json
+++ b/ajax/libs/angular-materialize/package.json
@@ -20,7 +20,7 @@
   "npmName": "angular-materialize",
   "npmFileMap": [
     {
-      "basePath": "/src",
+      "basePath": "src",
       "files": [
         "angular-materialize.js",
         "angular-materialize.min.js"

--- a/ajax/libs/angular-md5/package.json
+++ b/ajax/libs/angular-md5/package.json
@@ -25,7 +25,7 @@
   "npmName": "angular-md5",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "angular-md5.js",
         "angular-md5.min.js",

--- a/ajax/libs/angular-moment/package.json
+++ b/ajax/libs/angular-moment/package.json
@@ -6,7 +6,7 @@
   "npmName": "angular-moment",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "angular-moment.js",
         "angular-moment.min.js",

--- a/ajax/libs/angular-nvd3/package.json
+++ b/ajax/libs/angular-nvd3/package.json
@@ -22,7 +22,7 @@
   "npmName": "angular-nvd3",
   "npmFileMap": [
     {
-      "basePath": "dist/",
+      "basePath": "dist",
       "files": [
         "**/*"
       ]

--- a/ajax/libs/angular-recaptcha/package.json
+++ b/ajax/libs/angular-recaptcha/package.json
@@ -19,7 +19,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/vividcortex/angular-recaptcha.git",
-    "basePath": "release/",
+    "basePath": "release",
     "files": [
       "angular-recaptcha*.js"
     ]

--- a/ajax/libs/angular-retina/package.json
+++ b/ajax/libs/angular-retina/package.json
@@ -6,7 +6,7 @@
   "npmName": "angular-retina",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/angular-route-segment/package.json
+++ b/ajax/libs/angular-route-segment/package.json
@@ -14,7 +14,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/artch/angular-route-segment.git",
-    "basePath": "build/",
+    "basePath": "build",
     "files": [
       "*"
     ]

--- a/ajax/libs/angular-schema-form/package.json
+++ b/ajax/libs/angular-schema-form/package.json
@@ -26,7 +26,7 @@
   "npmName": "angular-schema-form",
   "npmFileMap": [
     {
-      "basePath": "/dist",
+      "basePath": "dist",
       "files": [
         "**/*"
       ]

--- a/ajax/libs/angular-spinner/package.json
+++ b/ajax/libs/angular-spinner/package.json
@@ -6,7 +6,7 @@
   "npmName": "angular-spinner",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "angular-spinner.js",
         "angular-spinner.min.js",

--- a/ajax/libs/angular-strap/package.json
+++ b/ajax/libs/angular-strap/package.json
@@ -13,7 +13,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/mgcrea/angular-strap.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "**/*"
     ]

--- a/ajax/libs/angular-ui-router/package.json
+++ b/ajax/libs/angular-ui-router/package.json
@@ -16,7 +16,7 @@
   "npmName": "angular-ui-router",
   "npmFileMap": [
     {
-      "basePath": "/release/",
+      "basePath": "release",
       "files": [
         "angular-ui-router.min.js",
         "angular-ui-router.js"

--- a/ajax/libs/angular-ui-tree/package.json
+++ b/ajax/libs/angular-ui-tree/package.json
@@ -21,7 +21,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/angular-ui-tree/angular-ui-tree.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "**/*"
     ]

--- a/ajax/libs/angular-vertxbus/package.json
+++ b/ajax/libs/angular-vertxbus/package.json
@@ -3,7 +3,7 @@
   "npmName": "angular-vertxbus",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/angular-wizard/package.json
+++ b/ajax/libs/angular-wizard/package.json
@@ -3,7 +3,7 @@
   "npmName": "angular-wizard",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.css",
         "*.js"

--- a/ajax/libs/angular-xeditable/package.json
+++ b/ajax/libs/angular-xeditable/package.json
@@ -14,7 +14,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/vitalets/angular-xeditable.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "**/*"
     ]

--- a/ajax/libs/angulartics-google-analytics/package.json
+++ b/ajax/libs/angulartics-google-analytics/package.json
@@ -22,7 +22,7 @@
   "npmName": "angulartics-google-analytics",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "**/*"
       ]

--- a/ajax/libs/anima/package.json
+++ b/ajax/libs/anima/package.json
@@ -19,7 +19,7 @@
   "npmName": "anima",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "anima.js",
         "anima.min.js",

--- a/ajax/libs/annyang/package.json
+++ b/ajax/libs/annyang/package.json
@@ -22,7 +22,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/TalAter/annyang.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "**/*"
     ]

--- a/ajax/libs/api-check/package.json
+++ b/ajax/libs/api-check/package.json
@@ -23,7 +23,7 @@
   "npmName": "api-check",
   "npmFileMap": [
     {
-      "basePath": "/dist",
+      "basePath": "dist",
       "files": [
         "*"
       ]

--- a/ajax/libs/architect/package.json
+++ b/ajax/libs/architect/package.json
@@ -13,7 +13,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/EtienneLem/architect.git",
-    "basePath": "static/",
+    "basePath": "static",
     "files": [
       "architect.min.js",
       "workers/ajax_worker.min.js",

--- a/ajax/libs/atmosphere/package.json
+++ b/ajax/libs/atmosphere/package.json
@@ -15,7 +15,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/Atmosphere/atmosphere-javascript.git",
-    "basePath": "modules/javascript/src/main/webapp/javascript/",
+    "basePath": "modules/javascript/src/main/webapp/javascript",
     "files": [
       "atmosphere.js"
     ]

--- a/ajax/libs/audio5js/package.json
+++ b/ajax/libs/audio5js/package.json
@@ -18,7 +18,7 @@
   "npmName": "audio5",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "audio5.js",
         "audio5.min.js",

--- a/ajax/libs/autocomplete.js/package.json
+++ b/ajax/libs/autocomplete.js/package.json
@@ -17,7 +17,7 @@
   "npmName": "autocomplete.js",
   "npmFileMap": [
     {
-      "basePath": "/dist",
+      "basePath": "dist",
       "files": [
         "**/*"
       ]

--- a/ajax/libs/awesome-bootstrap-checkbox/package.json
+++ b/ajax/libs/awesome-bootstrap-checkbox/package.json
@@ -12,7 +12,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/flatlogic/awesome-bootstrap-checkbox.git",
-    "basePath": "/",
+    "basePath": "",
     "files": [
       "awesome-bootstrap-checkbox.css"
     ]

--- a/ajax/libs/backbone-associations/package.json
+++ b/ajax/libs/backbone-associations/package.json
@@ -28,7 +28,7 @@
   "npmName": "backbone-associations",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "backbone-associations-min.js",
         "backbone-associations.js"

--- a/ajax/libs/backbone-forms/package.json
+++ b/ajax/libs/backbone-forms/package.json
@@ -10,7 +10,7 @@
   "npmName": "backbone-forms",
   "npmFileMap": [
     {
-      "basePath": "/distribution/",
+      "basePath": "distribution",
       "files": [
         "**/*"
       ]

--- a/ajax/libs/backbone-localstorage.js/package.json
+++ b/ajax/libs/backbone-localstorage.js/package.json
@@ -10,7 +10,7 @@
   "npmName": "backbone.localstorage",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "backbone.localStorage-min.js",
         "backbone.localStorage.js"

--- a/ajax/libs/backbone-pageable/package.json
+++ b/ajax/libs/backbone-pageable/package.json
@@ -15,7 +15,7 @@
   "npmName": "backbone-pageable",
   "npmFileMap": [
     {
-      "basePath": "/lib/",
+      "basePath": "lib",
       "files": [
         "backbone-pageable.js",
         "backbone-pageable.min.js"

--- a/ajax/libs/backbone-react-component/package.json
+++ b/ajax/libs/backbone-react-component/package.json
@@ -26,7 +26,7 @@
   "npmName": "backbone-react-component",
   "npmFileMap": [
     {
-      "basePath": "/dist",
+      "basePath": "dist",
       "files": [
         "/backbone-react-component-min.js",
         "/backbone-react-component.js"

--- a/ajax/libs/backbone-relational/package.json
+++ b/ajax/libs/backbone-relational/package.json
@@ -14,7 +14,7 @@
   "npmName": "backbone-relational",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/backbone.babysitter/package.json
+++ b/ajax/libs/backbone.babysitter/package.json
@@ -29,7 +29,7 @@
   "npmName": "backbone.babysitter",
   "npmFileMap": [
     {
-      "basePath": "/lib/",
+      "basePath": "lib",
       "files": [
         "*.js",
         "*.map"

--- a/ajax/libs/backbone.collectionView/package.json
+++ b/ajax/libs/backbone.collectionView/package.json
@@ -26,7 +26,7 @@
   "npmName": "bb-collection-view",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/backbone.js/package.json
+++ b/ajax/libs/backbone.js/package.json
@@ -14,7 +14,7 @@
   "npmName": "backbone",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "backbone.js",
         "backbone-min.js",

--- a/ajax/libs/backbone.layoutmanager/package.json
+++ b/ajax/libs/backbone.layoutmanager/package.json
@@ -13,7 +13,7 @@
   "npmName": "backbone.layoutmanager",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/backbone.validation/package.json
+++ b/ajax/libs/backbone.validation/package.json
@@ -3,7 +3,7 @@
   "npmName": "backbone-validation",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "backbone-validation-amd-min.js",
         "backbone-validation-amd.js",

--- a/ajax/libs/bacon.js/package.json
+++ b/ajax/libs/bacon.js/package.json
@@ -16,7 +16,7 @@
   "npmName": "baconjs",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/barn/package.json
+++ b/ajax/libs/barn/package.json
@@ -11,7 +11,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/arokor/barn.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "**/*"
     ]

--- a/ajax/libs/basis.js/package.json
+++ b/ajax/libs/basis.js/package.json
@@ -13,7 +13,7 @@
   "npmName": "basis-library",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/basket.js/package.json
+++ b/ajax/libs/basket.js/package.json
@@ -3,7 +3,7 @@
   "npmName": "basket.js",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*"
       ]

--- a/ajax/libs/bean/package.json
+++ b/ajax/libs/bean/package.json
@@ -22,7 +22,7 @@
   "npmName": "bean",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "bean.js",
         "bean.min.js"

--- a/ajax/libs/benchmark/package.json
+++ b/ajax/libs/benchmark/package.json
@@ -18,7 +18,7 @@
   "npmName": "benchmark",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "benchmark.js"
       ]

--- a/ajax/libs/bespoke.js/package.json
+++ b/ajax/libs/bespoke.js/package.json
@@ -11,7 +11,7 @@
   "npmName": "bespoke",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "bespoke.js",
         "bespoke.min.js"

--- a/ajax/libs/bignumber.js/package.json
+++ b/ajax/libs/bignumber.js/package.json
@@ -21,7 +21,7 @@
   "npmName": "bignumber.js",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "bignumber.min.js",
         "bignumber.js",

--- a/ajax/libs/bla/package.json
+++ b/ajax/libs/bla/package.json
@@ -3,7 +3,7 @@
   "npmName": "bla",
   "npmFileMap": [
     {
-      "basePath": "/build/",
+      "basePath": "build",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/blueimp-gallery/package.json
+++ b/ajax/libs/blueimp-gallery/package.json
@@ -34,7 +34,7 @@
   "npmName": "blueimp-gallery",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "css/blueimp-gallery-indicator.css",
         "css/blueimp-gallery-video.css",

--- a/ajax/libs/blueimp-md5/package.json
+++ b/ajax/libs/blueimp-md5/package.json
@@ -19,7 +19,7 @@
   "npmName": "blueimp-md5",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "js/md5.js",
         "js/md5.min.js"

--- a/ajax/libs/bootcards/package.json
+++ b/ajax/libs/bootcards/package.json
@@ -17,7 +17,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/bootcards/bootcards.git",
-    "basePath": "/dist/",
+    "basePath": "dist",
     "files": [
       "**/*"
     ]

--- a/ajax/libs/bootstrap-confirmation/package.json
+++ b/ajax/libs/bootstrap-confirmation/package.json
@@ -11,7 +11,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/tavicu/bs-confirmation.git",
-    "basePath": "/",
+    "basePath": "",
     "files": [
       "bootstrap-confirmation.js"
     ]

--- a/ajax/libs/bootstrap-markdown/package.json
+++ b/ajax/libs/bootstrap-markdown/package.json
@@ -12,7 +12,7 @@
   "npmName": "bootstrap-markdown",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "css/bootstrap-markdown.min.css",
         "js/bootstrap-markdown.js"

--- a/ajax/libs/bootstrap-select/package.json
+++ b/ajax/libs/bootstrap-select/package.json
@@ -26,7 +26,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/silviomoreto/bootstrap-select.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "**/*"
     ]

--- a/ajax/libs/bootstrap-slider/package.json
+++ b/ajax/libs/bootstrap-slider/package.json
@@ -19,7 +19,7 @@
   "readmeFilename": "README.md",
   "npmFileMap": [
     {
-      "basePath": "/dist",
+      "basePath": "dist",
       "files": [
         "**/*"
       ]

--- a/ajax/libs/bootstrap-switch/package.json
+++ b/ajax/libs/bootstrap-switch/package.json
@@ -27,7 +27,7 @@
   "readmeFilename": "README.md",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*"
       ]

--- a/ajax/libs/bootstrap-table/package.json
+++ b/ajax/libs/bootstrap-table/package.json
@@ -11,7 +11,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/wenzhixin/bootstrap-table.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "**/*"
     ]

--- a/ajax/libs/bootstrap-tokenfield/package.json
+++ b/ajax/libs/bootstrap-tokenfield/package.json
@@ -18,7 +18,7 @@
   "npmName": "bootstrap-tokenfield",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*",
         "css/*"

--- a/ajax/libs/bootstrap-tour/package.json
+++ b/ajax/libs/bootstrap-tour/package.json
@@ -31,7 +31,7 @@
   "npmName": "bootstrap-tour",
   "npmFileMap": [
     {
-      "basePath": "/build/",
+      "basePath": "build",
       "files": [
         "*"
       ]

--- a/ajax/libs/bricklayer/package.json
+++ b/ajax/libs/bricklayer/package.json
@@ -14,7 +14,7 @@
   "npmName": "bricklayer",
   "npmFileMap": [
     {
-      "basePath": "dist/",
+      "basePath": "dist",
       "files": [
         "**/!(*node*)"
       ]

--- a/ajax/libs/bttrlazyloading/package.json
+++ b/ajax/libs/bttrlazyloading/package.json
@@ -14,7 +14,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/shprink/BttrLazyLoading.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "**/*"
     ]

--- a/ajax/libs/caiuss/package.json
+++ b/ajax/libs/caiuss/package.json
@@ -17,7 +17,7 @@
   "npmName": "caiuss",
   "npmFileMap": [
     {
-      "basePath": "/dist",
+      "basePath": "dist",
       "files": [
         "*"
       ]

--- a/ajax/libs/camanjs/package.json
+++ b/ajax/libs/camanjs/package.json
@@ -16,7 +16,7 @@
   "npmName": "caman",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*"
       ]

--- a/ajax/libs/cannon.js/package.json
+++ b/ajax/libs/cannon.js/package.json
@@ -11,7 +11,7 @@
   "npmName": "cannon",
   "npmFileMap": [
     {
-      "basePath": "/build/",
+      "basePath": "build",
       "files": [
         "cannon.min.js",
         "cannon.js"

--- a/ajax/libs/catiline/package.json
+++ b/ajax/libs/catiline/package.json
@@ -3,7 +3,7 @@
   "npmName": "catiline",
   "npmFileMap": [
     {
-      "basePath": "/dist",
+      "basePath": "dist",
       "files": [
         "catiline*.js"
       ]

--- a/ajax/libs/chai/package.json
+++ b/ajax/libs/chai/package.json
@@ -4,7 +4,7 @@
   "npmName": "chai",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "chai*.js"
       ]

--- a/ajax/libs/chainloading/package.json
+++ b/ajax/libs/chainloading/package.json
@@ -18,7 +18,7 @@
   "npmName": "chainloading",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "chainloading.min.js"
       ]

--- a/ajax/libs/chardin.js/package.json
+++ b/ajax/libs/chardin.js/package.json
@@ -17,7 +17,7 @@
   "npmName": "chardin.js",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "chardinjs.css",
         "chardinjs.js",

--- a/ajax/libs/chroma-js/package.json
+++ b/ajax/libs/chroma-js/package.json
@@ -14,7 +14,7 @@
   "npmName": "chroma-js",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "chroma.min.js"
       ]

--- a/ajax/libs/cldrjs/package.json
+++ b/ajax/libs/cldrjs/package.json
@@ -33,7 +33,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/rxaviers/cldrjs.git",
-    "basePath": "/dist",
+    "basePath": "dist",
     "files": [
       "cldr.js",
       "cldr.min.js",

--- a/ajax/libs/clipboard.js/package.json
+++ b/ajax/libs/clipboard.js/package.json
@@ -22,7 +22,7 @@
   "npmName": "clipboard",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "**/*"
       ]

--- a/ajax/libs/codemirror/package.json
+++ b/ajax/libs/codemirror/package.json
@@ -16,13 +16,13 @@
   "npmName": "codemirror",
   "npmFileMap": [
     {
-      "basePath": "/lib/",
+      "basePath": "lib",
       "files": [
         "*.+(js|css)"
       ]
     },
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "+(addon|theme|mode|keymap)/**/*.+(js|css)"
       ]

--- a/ajax/libs/coffee-script/package.json
+++ b/ajax/libs/coffee-script/package.json
@@ -15,7 +15,7 @@
   "npmName": "coffee-script",
   "npmFileMap": [
     {
-      "basePath": "/lib/coffee-script/",
+      "basePath": "lib/coffee-script",
       "files": [
         "coffee-script.js"
       ]

--- a/ajax/libs/componentjs/package.json
+++ b/ajax/libs/componentjs/package.json
@@ -3,7 +3,7 @@
   "npmName": "componentjs",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "component.js",
         "component.min.js",

--- a/ajax/libs/condition/package.json
+++ b/ajax/libs/condition/package.json
@@ -9,7 +9,7 @@
   "npmName": "condition",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "condition.js",
         "condition.min.js"

--- a/ajax/libs/crel/package.json
+++ b/ajax/libs/crel/package.json
@@ -10,7 +10,7 @@
   "npmName": "crel",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "crel.js",
         "crel.min.js"

--- a/ajax/libs/crossfilter/package.json
+++ b/ajax/libs/crossfilter/package.json
@@ -20,7 +20,7 @@
   "npmName": "crossfilter",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "crossfilter.js",
         "crossfilter.min.js"

--- a/ajax/libs/cubism/package.json
+++ b/ajax/libs/cubism/package.json
@@ -23,7 +23,7 @@
   "npmName": "cubism",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "cubism.v1.js",
         "cubism.v1.min.js"

--- a/ajax/libs/custom-elements-builder/package.json
+++ b/ajax/libs/custom-elements-builder/package.json
@@ -5,7 +5,7 @@
   "npmName": "ceb",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js",
         "*.map"

--- a/ajax/libs/cutjs/package.json
+++ b/ajax/libs/cutjs/package.json
@@ -21,7 +21,7 @@
   "npmName": "cutjs",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/d3-geo-projection/package.json
+++ b/ajax/libs/d3-geo-projection/package.json
@@ -19,7 +19,7 @@
   "npmName": "d3-geo-projection",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "d3.geo.projection.js",
         "d3.geo.projection.min.js"

--- a/ajax/libs/d3plus/package.json
+++ b/ajax/libs/d3plus/package.json
@@ -32,7 +32,7 @@
   "npmName": "d3plus",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "d3plus.full.js",
         "d3plus.full.min.js",

--- a/ajax/libs/dancer.js/package.json
+++ b/ajax/libs/dancer.js/package.json
@@ -10,7 +10,7 @@
   "npmName": "dancer",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "dancer.js",
         "dancer.min.js",

--- a/ajax/libs/danialfarid-angular-file-upload/package.json
+++ b/ajax/libs/danialfarid-angular-file-upload/package.json
@@ -3,7 +3,7 @@
   "npmName": "ng-file-upload",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js",
         "*.swf"

--- a/ajax/libs/dat-gui/package.json
+++ b/ajax/libs/dat-gui/package.json
@@ -15,7 +15,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/dataarts/dat.gui.git",
-    "basePath": "build/",
+    "basePath": "build",
     "files": [
       "dat.gui*.js"
     ]

--- a/ajax/libs/dc/package.json
+++ b/ajax/libs/dc/package.json
@@ -30,7 +30,7 @@
   "npmName": "dc",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "dc.css",
         "dc.min.css",

--- a/ajax/libs/depot/package.json
+++ b/ajax/libs/depot/package.json
@@ -6,7 +6,7 @@
   "npmName": "depot",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "depot.js",
         "depot.min.js"

--- a/ajax/libs/device.js/package.json
+++ b/ajax/libs/device.js/package.json
@@ -14,7 +14,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/matthewhudson/device.js.git",
-    "basePath": "/lib/",
+    "basePath": "lib",
     "files": [
       "*"
     ]

--- a/ajax/libs/diva.js/package.json
+++ b/ajax/libs/diva.js/package.json
@@ -6,7 +6,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/DDMAL/diva.js.git",
-    "basePath": "/build/",
+    "basePath": "build",
     "files": [
       "js/**/*diva*",
       "css/**/*diva*",

--- a/ajax/libs/document-register-element/package.json
+++ b/ajax/libs/document-register-element/package.json
@@ -26,7 +26,7 @@
   "npmName": "document-register-element",
   "npmFileMap": [
     {
-      "basePath": "/build/",
+      "basePath": "build",
       "files": [
         "!(*.node.js)"
       ]

--- a/ajax/libs/dom4/package.json
+++ b/ajax/libs/dom4/package.json
@@ -22,7 +22,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/WebReflection/dom4.git",
-    "basePath": "/build/",
+    "basePath": "build",
     "files": [
       "dom4.js",
       "dom4.max.js"

--- a/ajax/libs/domainr-search-box/package.json
+++ b/ajax/libs/domainr-search-box/package.json
@@ -20,7 +20,7 @@
   "npmName": "domainr-search-box",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "**/*"
       ]

--- a/ajax/libs/domplotter/package.json
+++ b/ajax/libs/domplotter/package.json
@@ -18,7 +18,7 @@
   "npmName": "domplotter",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/draggabilly/package.json
+++ b/ajax/libs/draggabilly/package.json
@@ -11,7 +11,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/desandro/draggabilly.git",
-    "basePath": "/dist/",
+    "basePath": "dist",
     "files": [
       "draggabilly.pkgd.js",
       "draggabilly.pkgd.min.js"

--- a/ajax/libs/dropzone/package.json
+++ b/ajax/libs/dropzone/package.json
@@ -12,7 +12,7 @@
   "npmName": "dropzone",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js",
         "*.css",

--- a/ajax/libs/dustjs-helpers/package.json
+++ b/ajax/libs/dustjs-helpers/package.json
@@ -14,7 +14,7 @@
   "npmName": "dustjs-helpers",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/dustjs-linkedin/package.json
+++ b/ajax/libs/dustjs-linkedin/package.json
@@ -14,7 +14,7 @@
   "npmName": "dustjs-linkedin",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/eddy/package.json
+++ b/ajax/libs/eddy/package.json
@@ -29,7 +29,7 @@
   "npmName": "eddy",
   "npmFileMap": [
     {
-      "basePath": "/build/",
+      "basePath": "build",
       "files": [
         "eddy.dom.js",
         "eddy.dom.max.js",

--- a/ajax/libs/ekko-lightbox/package.json
+++ b/ajax/libs/ekko-lightbox/package.json
@@ -24,7 +24,7 @@
   "npmName": "ekko-lightbox",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*"
       ]

--- a/ajax/libs/elasticsearch/package.json
+++ b/ajax/libs/elasticsearch/package.json
@@ -15,7 +15,7 @@
   "npmName": "elasticsearch-browser",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/ember-dialog/package.json
+++ b/ajax/libs/ember-dialog/package.json
@@ -17,7 +17,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/wheely/ember-dialog.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "ember.dialog.min.css",
       "ember.dialog.min.js"

--- a/ajax/libs/ember-i18n/package.json
+++ b/ajax/libs/ember-i18n/package.json
@@ -17,7 +17,7 @@
   "npmName": "ember-i18n",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/emblem/package.json
+++ b/ajax/libs/emblem/package.json
@@ -14,7 +14,7 @@
   "npmName": "emblem",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "emblem.js",
         "emblem.min.js"

--- a/ajax/libs/es5-shim/package.json
+++ b/ajax/libs/es5-shim/package.json
@@ -3,7 +3,7 @@
   "npmName": "es5-shim",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "es5*"
       ]

--- a/ajax/libs/eve.js/package.json
+++ b/ajax/libs/eve.js/package.json
@@ -7,7 +7,7 @@
   "npmName": "eve.js",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "eve.min.js"
       ]

--- a/ajax/libs/evil-icons/package.json
+++ b/ajax/libs/evil-icons/package.json
@@ -5,7 +5,7 @@
   "npmName": "evil-icons",
   "npmFileMap": [
     {
-      "basePath": "/assets/",
+      "basePath": "assets",
       "files": [
         "evil-icons.min.js",
         "evil-icons.min.css"

--- a/ajax/libs/fast-json-patch/package.json
+++ b/ajax/libs/fast-json-patch/package.json
@@ -11,7 +11,7 @@
   "npmName": "fast-json-patch",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/flickity/package.json
+++ b/ajax/libs/flickity/package.json
@@ -15,7 +15,7 @@
   "npmName": "flickity",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*"
       ]

--- a/ajax/libs/floatthead/package.json
+++ b/ajax/libs/floatthead/package.json
@@ -11,7 +11,7 @@
   "npmName": "floatthead",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/fotorama/package.json
+++ b/ajax/libs/fotorama/package.json
@@ -33,7 +33,7 @@
   "npmName": "fotorama",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "fotorama*"
       ]

--- a/ajax/libs/free-jqgrid/package.json
+++ b/ajax/libs/free-jqgrid/package.json
@@ -3,7 +3,7 @@
   "npmName": "free-jqgrid",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "css/*",
         "js/*",

--- a/ajax/libs/fullcalendar/package.json
+++ b/ajax/libs/fullcalendar/package.json
@@ -29,7 +29,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/fullcalendar/fullcalendar.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "**/*"
     ]

--- a/ajax/libs/function-plot/package.json
+++ b/ajax/libs/function-plot/package.json
@@ -33,7 +33,7 @@
   "npmName": "function-plot",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "**/*"
       ]

--- a/ajax/libs/furtive/package.json
+++ b/ajax/libs/furtive/package.json
@@ -15,7 +15,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/johnotander/furtive.git",
-    "basePath": "css/",
+    "basePath": "css",
     "files": [
       "furtive*.css"
     ]

--- a/ajax/libs/fuse.js/package.json
+++ b/ajax/libs/fuse.js/package.json
@@ -11,7 +11,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/krisk/Fuse.git",
-    "basePath": "src/",
+    "basePath": "src",
     "files": [
       "*"
     ]

--- a/ajax/libs/galleria/package.json
+++ b/ajax/libs/galleria/package.json
@@ -14,7 +14,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/aino/galleria.git",
-    "basePath": "src/",
+    "basePath": "src",
     "files": [
       "**/*.gif",
       "**/*.css",

--- a/ajax/libs/geojs/package.json
+++ b/ajax/libs/geojs/package.json
@@ -27,7 +27,7 @@
   "npmName": "geojs",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "geo*.js"
       ]

--- a/ajax/libs/geojson2svg/package.json
+++ b/ajax/libs/geojson2svg/package.json
@@ -20,7 +20,7 @@
   "npmName": "geojson2svg",
   "npmFileMap": [
     {
-      "basePath": "/dist",
+      "basePath": "dist",
       "files": [
         "*"
       ]

--- a/ajax/libs/gh.js/package.json
+++ b/ajax/libs/gh.js/package.json
@@ -21,7 +21,7 @@
   "npmName": "gh.js",
   "npmFileMap": [
     {
-      "basePath": "/dist",
+      "basePath": "dist",
       "files": [
         "**/*"
       ]

--- a/ajax/libs/github-org-members.js/package.json
+++ b/ajax/libs/github-org-members.js/package.json
@@ -16,7 +16,7 @@
   "npmName": "github-org-members.js",
   "npmFileMap": [
     {
-      "basePath": "/src",
+      "basePath": "src",
       "files": [
         "*"
       ]

--- a/ajax/libs/gl-matrix/package.json
+++ b/ajax/libs/gl-matrix/package.json
@@ -3,7 +3,7 @@
   "npmName": "gl-matrix",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/golden-layout/package.json
+++ b/ajax/libs/golden-layout/package.json
@@ -23,13 +23,13 @@
   "npmName": "golden-layout",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "**/*"
       ]
     },
     {
-      "basePath": "/src/",
+      "basePath": "src",
       "files": [
         "css/+(goldenlayout*|*-theme).css"
       ]

--- a/ajax/libs/gorillascript/package.json
+++ b/ajax/libs/gorillascript/package.json
@@ -3,7 +3,7 @@
   "npmName": "gorillascript",
   "npmFileMap": [
     {
-      "basePath": "/extras/",
+      "basePath": "extras",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/grd/package.json
+++ b/ajax/libs/grd/package.json
@@ -22,7 +22,7 @@
   "npmName": "grd",
   "npmFileMap": [
     {
-      "basePath": "/dist",
+      "basePath": "dist",
       "files": [
         "**/*"
       ]

--- a/ajax/libs/gridly/package.json
+++ b/ajax/libs/gridly/package.json
@@ -21,7 +21,7 @@
   "npmName": "gridly",
   "npmFileMap": [
     {
-      "basePath": "/dist",
+      "basePath": "dist",
       "files": [
         "**/*"
       ]

--- a/ajax/libs/gsap/package.json
+++ b/ajax/libs/gsap/package.json
@@ -25,7 +25,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/greensock/GreenSock-JS.git",
-    "basePath": "src/minified/",
+    "basePath": "src/minified",
     "files": [
       "**/*"
     ]

--- a/ajax/libs/handjs/package.json
+++ b/ajax/libs/handjs/package.json
@@ -16,7 +16,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/deltakosh/handjs.git",
-    "basePath": "/bin/",
+    "basePath": "bin",
     "files": [
       "hand.js",
       "hand.min.js"

--- a/ajax/libs/handlebars.js/package.json
+++ b/ajax/libs/handlebars.js/package.json
@@ -11,7 +11,7 @@
   "npmName": "handlebars",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "handlebars.amd.js",
         "handlebars.amd.min.js",

--- a/ajax/libs/headhesive/package.json
+++ b/ajax/libs/headhesive/package.json
@@ -17,7 +17,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/markgoodyear/headhesive.js.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "**/*"
     ]

--- a/ajax/libs/hiw-api/package.json
+++ b/ajax/libs/hiw-api/package.json
@@ -17,7 +17,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/HealthIndicators/js-api.git",
-    "basePath": "Content/Scripts/API/Output/",
+    "basePath": "Content/Scripts/API/Output",
     "files": [
       "hiw-api.js",
       "hiw-api.min.js",

--- a/ajax/libs/horsey/package.json
+++ b/ajax/libs/horsey/package.json
@@ -13,7 +13,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/bevacqua/horsey.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "**/*"
     ]

--- a/ajax/libs/hprose-html5/package.json
+++ b/ajax/libs/hprose-html5/package.json
@@ -31,7 +31,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/hprose/hprose-html5.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "hprose-html5.js"
     ]

--- a/ajax/libs/html5media/package.json
+++ b/ajax/libs/html5media/package.json
@@ -19,7 +19,7 @@
   "npmName": "html5media",
   "npmFileMap": [
     {
-      "basePath": "/dist/api/",
+      "basePath": "dist/api",
       "files": [
         "*.js",
         "*.swf"

--- a/ajax/libs/hydra.js/package.json
+++ b/ajax/libs/hydra.js/package.json
@@ -14,7 +14,7 @@
   "npmName": "hydra.js",
   "npmFileMap": [
     {
-      "basePath": "/versions/",
+      "basePath": "versions",
       "files": [
         "hydra.js",
         "hydra.min.js"

--- a/ajax/libs/ice/package.json
+++ b/ajax/libs/ice/package.json
@@ -3,7 +3,7 @@
   "npmName": "ice",
   "npmFileMap": [
     {
-      "basePath": "/lib/",
+      "basePath": "lib",
       "files": [
         "*.js",
         "*.map"

--- a/ajax/libs/idbwrapper/package.json
+++ b/ajax/libs/idbwrapper/package.json
@@ -11,7 +11,7 @@
   "npmName": "idb-wrapper",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "idbstore.min.js"
       ]

--- a/ajax/libs/ie8/package.json
+++ b/ajax/libs/ie8/package.json
@@ -22,7 +22,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/WebReflection/ie8.git",
-    "basePath": "/build/",
+    "basePath": "build",
     "files": [
       "*.js"
     ]

--- a/ajax/libs/iframe-resizer/package.json
+++ b/ajax/libs/iframe-resizer/package.json
@@ -28,7 +28,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/davidjbradshaw/iframe-resizer.git",
-    "basePath": "js/",
+    "basePath": "js",
     "files": [
       "!(index)*.+(js|map)"
     ]

--- a/ajax/libs/immstruct/package.json
+++ b/ajax/libs/immstruct/package.json
@@ -21,7 +21,7 @@
   "npmName": "immstruct",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/immutable/package.json
+++ b/ajax/libs/immutable/package.json
@@ -18,7 +18,7 @@
   "npmName": "immutable",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/ink/package.json
+++ b/ajax/libs/ink/package.json
@@ -14,7 +14,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/sapo/Ink.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "js/*",
       "css/ink*.css",

--- a/ajax/libs/insightjs/package.json
+++ b/ajax/libs/insightjs/package.json
@@ -28,7 +28,7 @@
   "npmName": "insightjs",
   "npmFileMap": [
     {
-      "basePath": "dist/",
+      "basePath": "dist",
       "files": [
         "*.js",
         "*.css"

--- a/ajax/libs/intl-tel-input/package.json
+++ b/ajax/libs/intl-tel-input/package.json
@@ -23,7 +23,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/jackocnr/intl-tel-input.git",
-    "basePath": "build/",
+    "basePath": "build",
     "files": [
       "js/utils.js",
       "js/intlTelInput*.js",

--- a/ajax/libs/intro.js/package.json
+++ b/ajax/libs/intro.js/package.json
@@ -15,7 +15,7 @@
   "npmName": "intro.js",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "intro.js",
         "introjs.css",
@@ -23,7 +23,7 @@
       ]
     },
     {
-      "basePath": "/minified/",
+      "basePath": "minified",
       "files": [
         "*"
       ]

--- a/ajax/libs/jcarousel/package.json
+++ b/ajax/libs/jcarousel/package.json
@@ -16,7 +16,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/jsor/jcarousel.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "*.js"
     ]

--- a/ajax/libs/jinplace/package.json
+++ b/ajax/libs/jinplace/package.json
@@ -19,7 +19,7 @@
   "npmName": "jinplace",
   "npmFileMap": [
     {
-      "basePath": "/js/",
+      "basePath": "js",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/jit/package.json
+++ b/ajax/libs/jit/package.json
@@ -17,7 +17,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/philogb/jit.git",
-    "basePath": "Jit/",
+    "basePath": "Jit",
     "files": [
       "Extras/excanvas.js",
       "jit.js"

--- a/ajax/libs/jmpress/package.json
+++ b/ajax/libs/jmpress/package.json
@@ -3,7 +3,7 @@
   "npmName": "jmpress",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "*.js",
         "*.css",

--- a/ajax/libs/jplayer/package.json
+++ b/ajax/libs/jplayer/package.json
@@ -16,7 +16,7 @@
   "npmName": "jplayer",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "**/*.css",
         "**/*.js",

--- a/ajax/libs/jquery-bootgrid/package.json
+++ b/ajax/libs/jquery-bootgrid/package.json
@@ -4,7 +4,7 @@
   "npmName": "jquery-bootgrid",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.css",
         "*.js"

--- a/ajax/libs/jquery-browser/package.json
+++ b/ajax/libs/jquery-browser/package.json
@@ -3,7 +3,7 @@
   "npmName": "jquery.browser",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*"
       ]

--- a/ajax/libs/jquery-data-remote/package.json
+++ b/ajax/libs/jquery-data-remote/package.json
@@ -18,7 +18,7 @@
   "npmName": "jquery-data-remote",
   "npmFileMap": [
     {
-      "basePath": "/dist",
+      "basePath": "dist",
       "files": [
         "**/*"
       ]

--- a/ajax/libs/jquery-form-serializer/package.json
+++ b/ajax/libs/jquery-form-serializer/package.json
@@ -16,7 +16,7 @@
   "npmName": "jquery-form-serializer",
   "npmFileMap": [
     {
-      "basePath": "/src",
+      "basePath": "src",
       "files": [
         "*"
       ]

--- a/ajax/libs/jquery-image-upload/package.json
+++ b/ajax/libs/jquery-image-upload/package.json
@@ -16,7 +16,7 @@
   "npmName": "jquery-image-upload",
   "npmFileMap": [
     {
-      "basePath": "/src",
+      "basePath": "src",
       "files": [
         "*"
       ]

--- a/ajax/libs/jquery-impromptu/package.json
+++ b/ajax/libs/jquery-impromptu/package.json
@@ -22,7 +22,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/trentrichardson/jQuery-Impromptu.git",
-    "basePath": "/dist/",
+    "basePath": "dist",
     "files": [
       "**/*.js",
       "**/*.css"

--- a/ajax/libs/jquery-jgrowl/package.json
+++ b/ajax/libs/jquery-jgrowl/package.json
@@ -27,7 +27,7 @@
   "npmName": "jgrowl",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "jquery.jgrowl*css",
         "jquery.jgrowl*js",

--- a/ajax/libs/jquery-json-editor/package.json
+++ b/ajax/libs/jquery-json-editor/package.json
@@ -16,7 +16,7 @@
   "npmName": "jquery-json-editor",
   "npmFileMap": [
     {
-      "basePath": "/src",
+      "basePath": "src",
       "files": [
         "*"
       ]

--- a/ajax/libs/jquery-jsonview/package.json
+++ b/ajax/libs/jquery-jsonview/package.json
@@ -14,7 +14,7 @@
   "npmName": "jquery-jsonview",
   "npmFileMap": [
     {
-      "basePath": "/dist",
+      "basePath": "dist",
       "files": [
         "**/*.+(css|js)"
       ]

--- a/ajax/libs/jquery-lazyload-any/package.json
+++ b/ajax/libs/jquery-lazyload-any/package.json
@@ -11,7 +11,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/emn178/jquery-lazyload-any.git",
-    "basePath": "build/",
+    "basePath": "build",
     "files": [
       "jquery.lazyload-any.min.js"
     ]

--- a/ajax/libs/jquery-maskmoney/package.json
+++ b/ajax/libs/jquery-maskmoney/package.json
@@ -23,7 +23,7 @@
   "npmName": "jquery-maskmoney",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "jquery.maskMoney.min.js"
       ]

--- a/ajax/libs/jquery-migrate/package.json
+++ b/ajax/libs/jquery-migrate/package.json
@@ -3,7 +3,7 @@
   "npmName": "jquery-migrate",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "**/*"
       ]

--- a/ajax/libs/jquery-mobile/package.json
+++ b/ajax/libs/jquery-mobile/package.json
@@ -3,7 +3,7 @@
   "npmName": "jquery-mobile",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.css",
         "*.js",

--- a/ajax/libs/jquery-noty/package.json
+++ b/ajax/libs/jquery-noty/package.json
@@ -13,7 +13,7 @@
   "npmName": "noty",
   "npmFileMap": [
     {
-      "basePath": "/js/noty/",
+      "basePath": "js/noty",
       "files": [
         "**/*"
       ]

--- a/ajax/libs/jquery-once/package.json
+++ b/ajax/libs/jquery-once/package.json
@@ -10,7 +10,7 @@
   "npmName": "jquery-once",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "jquery.once.js",
         "jquery.once.min.js",

--- a/ajax/libs/jquery-prompt21/package.json
+++ b/ajax/libs/jquery-prompt21/package.json
@@ -15,7 +15,7 @@
   "npmName": "jquery-prompt21",
   "npmFileMap": [
     {
-      "basePath": "/src",
+      "basePath": "src",
       "files": [
         "*"
       ]

--- a/ajax/libs/jquery-searcher/package.json
+++ b/ajax/libs/jquery-searcher/package.json
@@ -20,7 +20,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/lloiser/jquery-searcher.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "*.js"
     ]

--- a/ajax/libs/jquery-sidebar/package.json
+++ b/ajax/libs/jquery-sidebar/package.json
@@ -16,7 +16,7 @@
   "npmName": "jquery-sidebar",
   "npmFileMap": [
     {
-      "basePath": "/src",
+      "basePath": "src",
       "files": [
         "*"
       ]

--- a/ajax/libs/jquery-smoove/package.json
+++ b/ajax/libs/jquery-smoove/package.json
@@ -13,7 +13,7 @@
   "npmName": "jquery-smoove",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/jquery-sortable/package.json
+++ b/ajax/libs/jquery-sortable/package.json
@@ -14,7 +14,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/johnny/jquery-sortable.git",
-    "basePath": "source/js/",
+    "basePath": "source/js",
     "files": [
       "jquery-sortable*.js"
     ]

--- a/ajax/libs/jquery-ui-timepicker-addon/package.json
+++ b/ajax/libs/jquery-ui-timepicker-addon/package.json
@@ -20,7 +20,7 @@
   "npmName": "jquery-ui-timepicker-addon",
   "npmFileMap": [
     {
-      "basePath": "/dist",
+      "basePath": "dist",
       "files": [
         "**/*.+(js|css)"
       ]

--- a/ajax/libs/jquery.age/package.json
+++ b/ajax/libs/jquery.age/package.json
@@ -21,7 +21,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/ksylvest/jquery-age.git",
-    "basePath": "/javascripts/",
+    "basePath": "javascripts",
     "files": [
       "jquery.age.js"
     ]

--- a/ajax/libs/jquery.allowed-chars/package.json
+++ b/ajax/libs/jquery.allowed-chars/package.json
@@ -23,7 +23,7 @@
   "npmName": "jquery.allowed-chars",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/jquery.bootstrapvalidator/package.json
+++ b/ajax/libs/jquery.bootstrapvalidator/package.json
@@ -15,7 +15,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/nghuuphuoc/bootstrapvalidator.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "**/*"
     ]

--- a/ajax/libs/jquery.devbridge-autocomplete/package.json
+++ b/ajax/libs/jquery.devbridge-autocomplete/package.json
@@ -11,7 +11,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/devbridge/jQuery-Autocomplete.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "jquery.autocomplete.min.js",
       "jquery.autocomplete.js"

--- a/ajax/libs/jquery.fancytree/package.json
+++ b/ajax/libs/jquery.fancytree/package.json
@@ -23,7 +23,7 @@
   "npmName": "jquery.fancytree",
   "npmFileMap": [
     {
-      "basePath": "dist/",
+      "basePath": "dist",
       "files": [
         "*.js",
         "*.js.map",

--- a/ajax/libs/jquery.formset/package.json
+++ b/ajax/libs/jquery.formset/package.json
@@ -20,7 +20,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/elo80ka/django-dynamic-formset.git",
-    "basePath": "src/",
+    "basePath": "src",
     "files": [
       "jquery.formset*.js"
     ]

--- a/ajax/libs/jquery.gridster/package.json
+++ b/ajax/libs/jquery.gridster/package.json
@@ -22,7 +22,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/ducksboard/gridster.js.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "**/*"
     ]

--- a/ajax/libs/jquery.hashcash.io/package.json
+++ b/ajax/libs/jquery.hashcash.io/package.json
@@ -21,7 +21,7 @@
   "npmName": "jquery.hashcash.io",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "*.js",
         "*.css"

--- a/ajax/libs/jquery.imagesloaded/package.json
+++ b/ajax/libs/jquery.imagesloaded/package.json
@@ -12,7 +12,7 @@
   "npmName": "imagesloaded",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "imagesloaded*.js"
       ]

--- a/ajax/libs/jquery.isotope/package.json
+++ b/ajax/libs/jquery.isotope/package.json
@@ -14,7 +14,7 @@
   "npmName": "isotope-layout",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*"
       ]

--- a/ajax/libs/jquery.lazyloadxt/package.json
+++ b/ajax/libs/jquery.lazyloadxt/package.json
@@ -25,7 +25,7 @@
   "npmName": "lazyloadxt",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*"
       ]

--- a/ajax/libs/jquery.nanoscroller/package.json
+++ b/ajax/libs/jquery.nanoscroller/package.json
@@ -13,7 +13,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/jamesflorentino/nanoScrollerJS.git",
-    "basePath": "bin/",
+    "basePath": "bin",
     "files": [
       "javascripts/jquery.nanoscroller.*",
       "css/nanoscroller.css"

--- a/ajax/libs/jquery.panzoom/package.json
+++ b/ajax/libs/jquery.panzoom/package.json
@@ -15,7 +15,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/timmywil/jquery.panzoom.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "**/*"
     ]

--- a/ajax/libs/jquery.photocols/package.json
+++ b/ajax/libs/jquery.photocols/package.json
@@ -13,7 +13,7 @@
   "npmName": "jquery.photocols",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "jquery.photocols.min.js"
       ]

--- a/ajax/libs/jquery.postcodify/package.json
+++ b/ajax/libs/jquery.postcodify/package.json
@@ -13,7 +13,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/kijin/postcodify.git",
-    "basePath": "api/",
+    "basePath": "api",
     "files": [
       "search.min.js"
     ]

--- a/ajax/libs/jquery.simpleWeather/package.json
+++ b/ajax/libs/jquery.simpleWeather/package.json
@@ -11,7 +11,7 @@
   "npmName": "simpleweather",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "jquery.simpleWeather.min.js"
       ]

--- a/ajax/libs/jquery.smartmenus/package.json
+++ b/ajax/libs/jquery.smartmenus/package.json
@@ -16,7 +16,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/vadikom/smartmenus.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "**/*.+(css|js)"
     ]

--- a/ajax/libs/jquery.textcomplete/package.json
+++ b/ajax/libs/jquery.textcomplete/package.json
@@ -3,7 +3,7 @@
   "npmName": "jquery-textcomplete",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "**/*"
       ]

--- a/ajax/libs/jquery.tipsy/package.json
+++ b/ajax/libs/jquery.tipsy/package.json
@@ -19,14 +19,14 @@
   "npmName": "jquery.tipsy",
   "npmFileMap": [
     {
-      "basePath": "/src/",
+      "basePath": "src",
       "files": [
         "*.js",
         "*.css"
       ]
     },
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/jquery.ui-contextmenu/package.json
+++ b/ajax/libs/jquery.ui-contextmenu/package.json
@@ -33,7 +33,7 @@
   "npmName": "ui-contextmenu",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "jquery.ui-contextmenu.min.js",
         "jquery.ui-contextmenu.min.js.map"

--- a/ajax/libs/jqueryui-touch-punch/package.json
+++ b/ajax/libs/jqueryui-touch-punch/package.json
@@ -12,7 +12,7 @@
   "npmName": "jquery-ui-touch-punch",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "jquery.ui.touch-punch.min.js"
       ]

--- a/ajax/libs/js-bson/package.json
+++ b/ajax/libs/js-bson/package.json
@@ -17,7 +17,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/mongodb/js-bson.git",
-    "basePath": "browser_build/",
+    "basePath": "browser_build",
     "files": [
       "bson*.js"
     ]

--- a/ajax/libs/js-data-angular/package.json
+++ b/ajax/libs/js-data-angular/package.json
@@ -15,7 +15,7 @@
   "npmName": "js-data-angular",
   "npmFileMap": [
     {
-      "basePath": "/dist",
+      "basePath": "dist",
       "files": [
         "*"
       ]

--- a/ajax/libs/js-data-firebase/package.json
+++ b/ajax/libs/js-data-firebase/package.json
@@ -26,7 +26,7 @@
   "npmName": "js-data-firebase",
   "npmFileMap": [
     {
-      "basePath": "/dist",
+      "basePath": "dist",
       "files": [
         "*"
       ]

--- a/ajax/libs/js-data-http/package.json
+++ b/ajax/libs/js-data-http/package.json
@@ -28,7 +28,7 @@
   "npmName": "js-data-http",
   "npmFileMap": [
     {
-      "basePath": "/dist",
+      "basePath": "dist",
       "files": [
         "**/*.+(!ts)"
       ]

--- a/ajax/libs/js-data-localforage/package.json
+++ b/ajax/libs/js-data-localforage/package.json
@@ -28,7 +28,7 @@
   "npmName": "js-data-localforage",
   "npmFileMap": [
     {
-      "basePath": "/dist",
+      "basePath": "dist",
       "files": [
         "*"
       ]

--- a/ajax/libs/js-data-localstorage/package.json
+++ b/ajax/libs/js-data-localstorage/package.json
@@ -25,7 +25,7 @@
   "npmName": "js-data-localstorage",
   "npmFileMap": [
     {
-      "basePath": "/dist",
+      "basePath": "dist",
       "files": [
         "**/*.+(js|map)"
       ]

--- a/ajax/libs/js-sequence-diagrams/package.json
+++ b/ajax/libs/js-sequence-diagrams/package.json
@@ -23,7 +23,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/bramp/js-sequence-diagrams.git",
-    "basePath": "/build/",
+    "basePath": "build",
     "files": [
       "sequence-diagram.js",
       "sequence-diagram-min.js",

--- a/ajax/libs/jsface/package.json
+++ b/ajax/libs/jsface/package.json
@@ -20,7 +20,7 @@
   "npmName": "jsface",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "**/*"
       ]

--- a/ajax/libs/jsfeat/package.json
+++ b/ajax/libs/jsfeat/package.json
@@ -20,7 +20,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/inspirit/jsfeat.git",
-    "basePath": "build/",
+    "basePath": "build",
     "files": [
       "jsfeat*.js"
     ]

--- a/ajax/libs/jsforce/package.json
+++ b/ajax/libs/jsforce/package.json
@@ -19,7 +19,7 @@
   "npmName": "jsforce",
   "npmFileMap": [
     {
-      "basePath": "/build/",
+      "basePath": "build",
       "files": [
         "*"
       ]

--- a/ajax/libs/jshint/package.json
+++ b/ajax/libs/jshint/package.json
@@ -20,7 +20,7 @@
   "npmName": "jshint",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "jshint.js"
       ]

--- a/ajax/libs/json3/package.json
+++ b/ajax/libs/json3/package.json
@@ -7,7 +7,7 @@
   "npmName": "json3",
   "npmFileMap": [
     {
-      "basePath": "/lib/",
+      "basePath": "lib",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/jsonld/package.json
+++ b/ajax/libs/jsonld/package.json
@@ -23,7 +23,7 @@
   "npmName": "jsonld",
   "npmFileMap": [
     {
-      "basePath": "/js/",
+      "basePath": "js",
       "files": [
         "jsonld.js"
       ]

--- a/ajax/libs/jsonlint/package.json
+++ b/ajax/libs/jsonlint/package.json
@@ -14,7 +14,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/zaach/jsonlint.git",
-    "basePath": "lib/",
+    "basePath": "lib",
     "files": [
       "jsonlint.js"
     ]

--- a/ajax/libs/jss/package.json
+++ b/ajax/libs/jss/package.json
@@ -24,7 +24,7 @@
   "npmName": "jss",
   "npmFileMap": [
     {
-      "basePath": "dist/",
+      "basePath": "dist",
       "files": [
         "**/*"
       ]

--- a/ajax/libs/jssip/package.json
+++ b/ajax/libs/jssip/package.json
@@ -4,7 +4,7 @@
   "npmName": "jssip",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "jssip.min.js",
         "jssip.js"

--- a/ajax/libs/jssor-slider/package.json
+++ b/ajax/libs/jssor-slider/package.json
@@ -35,7 +35,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/jssor/slider.git",
-    "basePath": "js/",
+    "basePath": "js",
     "files": [
       "jssor*.js"
     ]

--- a/ajax/libs/jstree/package.json
+++ b/ajax/libs/jstree/package.json
@@ -21,7 +21,7 @@
   "npmName": "jstree",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "jstree.min.js",
         "themes/**/*.png",

--- a/ajax/libs/jszip/package.json
+++ b/ajax/libs/jszip/package.json
@@ -12,7 +12,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/Stuk/jszip.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "jszip.js",
       "jszip.min.js"

--- a/ajax/libs/justifiedGallery/package.json
+++ b/ajax/libs/justifiedGallery/package.json
@@ -18,7 +18,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/miromannino/Justified-Gallery.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "**/*.+(js|css)"
     ]

--- a/ajax/libs/jxon/package.json
+++ b/ajax/libs/jxon/package.json
@@ -29,7 +29,7 @@
   "npmName": "jxon",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "index.js"
       ]

--- a/ajax/libs/kartograph-js/package.json
+++ b/ajax/libs/kartograph-js/package.json
@@ -17,7 +17,7 @@
   "npmName": "kartograph-js",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "kartograph.js",
         "kartograph.min.js"

--- a/ajax/libs/kineticjs/package.json
+++ b/ajax/libs/kineticjs/package.json
@@ -11,7 +11,7 @@
   "npmName": "kinetic",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "kinetic.js",
         "kinetic.min.js"

--- a/ajax/libs/klass/package.json
+++ b/ajax/libs/klass/package.json
@@ -14,7 +14,7 @@
   "npmName": "klass",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "klass.js",
         "klass.min.js"

--- a/ajax/libs/knockback/package.json
+++ b/ajax/libs/knockback/package.json
@@ -17,7 +17,7 @@
   "npmName": "knockback",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "knockback.min.js"
       ]

--- a/ajax/libs/knockout-paging/package.json
+++ b/ajax/libs/knockout-paging/package.json
@@ -19,7 +19,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/ErikSchierboom/knockout-paging.git",
-    "basePath": "/dist/",
+    "basePath": "dist",
     "files": [
       "knockout-paging.min.js",
       "knockout-paging.js"

--- a/ajax/libs/knockout-pre-rendered/package.json
+++ b/ajax/libs/knockout-pre-rendered/package.json
@@ -19,7 +19,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/ErikSchierboom/knockout-pre-rendered.git",
-    "basePath": "/dist/",
+    "basePath": "dist",
     "files": [
       "knockout-pre-rendered.min.js",
       "knockout-pre-rendered.js"

--- a/ajax/libs/knockout-validation/package.json
+++ b/ajax/libs/knockout-validation/package.json
@@ -15,7 +15,7 @@
   "npmName": "knockout.validation",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*"
       ]

--- a/ajax/libs/knockout/package.json
+++ b/ajax/libs/knockout/package.json
@@ -18,7 +18,7 @@
   "npmName": "knockout",
   "npmFileMap": [
     {
-      "basePath": "/build/output/",
+      "basePath": "build/output",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/kwargsjs/package.json
+++ b/ajax/libs/kwargsjs/package.json
@@ -25,7 +25,7 @@
   "npmName": "kwargsjs",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "kwargs.js"
       ]

--- a/ajax/libs/layzr.js/package.json
+++ b/ajax/libs/layzr.js/package.json
@@ -18,7 +18,7 @@
   "npmName": "layzr.js",
   "npmFileMap": [
     {
-      "basePath": "/dist",
+      "basePath": "dist",
       "files": [
         "**/*"
       ]

--- a/ajax/libs/leaflet-dvf/package.json
+++ b/ajax/libs/leaflet-dvf/package.json
@@ -12,7 +12,7 @@
   "npmName": "leaflet-dvf",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*"
       ]

--- a/ajax/libs/leaflet-hash/package.json
+++ b/ajax/libs/leaflet-hash/package.json
@@ -16,7 +16,7 @@
   "npmName": "leaflet-hash",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "leaflet-hash*.js"
       ]

--- a/ajax/libs/leaflet.markercluster/package.json
+++ b/ajax/libs/leaflet.markercluster/package.json
@@ -10,7 +10,7 @@
   "npmName": "leaflet.markercluster",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "MarkerCluster.Default.css",
         "MarkerCluster.css",

--- a/ajax/libs/leaflet/package.json
+++ b/ajax/libs/leaflet/package.json
@@ -11,7 +11,7 @@
   "npmName": "leaflet",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*"
       ]

--- a/ajax/libs/leapjs/package.json
+++ b/ajax/libs/leapjs/package.json
@@ -10,7 +10,7 @@
   "npmName": "leapjs",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "leap.min.js"
       ]

--- a/ajax/libs/legojs/package.json
+++ b/ajax/libs/legojs/package.json
@@ -6,7 +6,7 @@
   "npmName": "legojs",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "lego.min.js"
       ]

--- a/ajax/libs/less.js/package.json
+++ b/ajax/libs/less.js/package.json
@@ -16,7 +16,7 @@
   "npmName": "less",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "less.*js"
       ]

--- a/ajax/libs/libil/package.json
+++ b/ajax/libs/libil/package.json
@@ -14,7 +14,7 @@
   "npmName": "libil",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/lightcase/package.json
+++ b/ajax/libs/lightcase/package.json
@@ -20,7 +20,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/cbopp-art/lightcase.git",
-    "basePath": "src/",
+    "basePath": "src",
     "files": [
       "@(js|css|fonts)/*lightcase*"
     ]

--- a/ajax/libs/list.js/package.json
+++ b/ajax/libs/list.js/package.json
@@ -7,7 +7,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/javve/list.js.git",
-    "basePath": "/dist",
+    "basePath": "dist",
     "files": [
       "list.js",
       "list.min.js"

--- a/ajax/libs/list.pagination.js/package.json
+++ b/ajax/libs/list.pagination.js/package.json
@@ -16,7 +16,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/javve/list.pagination.js.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "*"
     ]

--- a/ajax/libs/localStorage/package.json
+++ b/ajax/libs/localStorage/package.json
@@ -11,7 +11,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/mortzdk/localStorage.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "*"
     ]

--- a/ajax/libs/localforage/package.json
+++ b/ajax/libs/localforage/package.json
@@ -3,7 +3,7 @@
   "npmName": "localforage",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/loglevel/package.json
+++ b/ajax/libs/loglevel/package.json
@@ -22,7 +22,7 @@
   "npmName": "loglevel",
   "npmFileMap": [
     {
-      "basePath": "/dist",
+      "basePath": "dist",
       "files": [
         "loglevel.min.js"
       ]

--- a/ajax/libs/lunr.js/package.json
+++ b/ajax/libs/lunr.js/package.json
@@ -10,7 +10,7 @@
   "npmName": "lunr",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "lunr.min.js"
       ]

--- a/ajax/libs/lz-string/package.json
+++ b/ajax/libs/lz-string/package.json
@@ -19,7 +19,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/pieroxy/lz-string.git",
-    "basePath": "libs/",
+    "basePath": "libs",
     "files": [
       "lz-string.js",
       "lz-string.min.js",

--- a/ajax/libs/m8tro-bootstrap/package.json
+++ b/ajax/libs/m8tro-bootstrap/package.json
@@ -25,7 +25,7 @@
   "npmName": "m8tro-bootstrap",
   "npmFileMap": [
     {
-      "basePath": "/dist/css/",
+      "basePath": "dist/css",
       "files": [
         "m8tro.min.css"
       ]

--- a/ajax/libs/machina.js/package.json
+++ b/ajax/libs/machina.js/package.json
@@ -35,7 +35,7 @@
   "npmName": "machina",
   "npmFileMap": [
     {
-      "basePath": "/lib/",
+      "basePath": "lib",
       "files": [
         "machina.js",
         "machina.min.js"

--- a/ajax/libs/maquette/package.json
+++ b/ajax/libs/maquette/package.json
@@ -18,7 +18,7 @@
   "npmName": "maquette",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/markdown.js/package.json
+++ b/ajax/libs/markdown.js/package.json
@@ -13,7 +13,7 @@
   "npmName": "markdown",
   "npmFileMap": [
     {
-      "basePath": "lib/",
+      "basePath": "lib",
       "files": [
         "markdown*.js"
       ]

--- a/ajax/libs/matreshka/package.json
+++ b/ajax/libs/matreshka/package.json
@@ -11,7 +11,7 @@
   "npmName": "matreshka",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "matreshka.js",
         "matreshka.min.js",

--- a/ajax/libs/medium-editor-custom-html/package.json
+++ b/ajax/libs/medium-editor-custom-html/package.json
@@ -17,7 +17,7 @@
   "npmName": "medium-editor-custom-html",
   "npmFileMap": [
     {
-      "basePath": "/src",
+      "basePath": "src",
       "files": [
         "*"
       ]

--- a/ajax/libs/metisMenu/package.json
+++ b/ajax/libs/metisMenu/package.json
@@ -17,7 +17,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/onokumus/metisMenu.git",
-    "basePath": "/dist/",
+    "basePath": "dist",
     "files": [
       "*"
     ]

--- a/ajax/libs/mindb/package.json
+++ b/ajax/libs/mindb/package.json
@@ -19,7 +19,7 @@
   "npmName": "min",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js",
         "*.map"

--- a/ajax/libs/mini-meteor/package.json
+++ b/ajax/libs/mini-meteor/package.json
@@ -3,7 +3,7 @@
   "npmName": "mini-meteor",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/minicart/package.json
+++ b/ajax/libs/minicart/package.json
@@ -15,7 +15,7 @@
   "npmName": "minicart",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "**/*"
       ]

--- a/ajax/libs/minitranslate/package.json
+++ b/ajax/libs/minitranslate/package.json
@@ -17,7 +17,7 @@
   "npmName": "minitranslate",
   "npmFileMap": [
     {
-      "basePath": "/js/",
+      "basePath": "js",
       "files": [
         "/minitranslate.js",
         "/minitranslate.min.js"

--- a/ajax/libs/mithril/package.json
+++ b/ajax/libs/mithril/package.json
@@ -17,7 +17,7 @@
   },
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "mithril.js",
         "mithril.min.js",

--- a/ajax/libs/mo/package.json
+++ b/ajax/libs/mo/package.json
@@ -21,7 +21,7 @@
   "npmName": "mo",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "browsers.js",
         "console.js",

--- a/ajax/libs/mocha/package.json
+++ b/ajax/libs/mocha/package.json
@@ -5,7 +5,7 @@
   "npmName": "mocha",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "mocha.js",
         "mocha.css"

--- a/ajax/libs/mojio-js/package.json
+++ b/ajax/libs/mojio-js/package.json
@@ -14,7 +14,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/mojio/mojio-js.git",
-    "basePath": "/dist/cdn/",
+    "basePath": "dist/cdn",
     "files": [
       "*.js"
     ]

--- a/ajax/libs/moment-duration-format/package.json
+++ b/ajax/libs/moment-duration-format/package.json
@@ -12,7 +12,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/jsmreese/moment-duration-format.git",
-    "basePath": "lib/",
+    "basePath": "lib",
     "files": [
       "moment-duration-format*.js"
     ]

--- a/ajax/libs/moment-range/package.json
+++ b/ajax/libs/moment-range/package.json
@@ -2,13 +2,13 @@
   "npmName": "moment-range",
   "npmFileMap": [
     {
-      "basePath": "/lib/",
+      "basePath": "lib",
       "files": [
         "*.js"
       ]
     },
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/moment-timezone/package.json
+++ b/ajax/libs/moment-timezone/package.json
@@ -13,7 +13,7 @@
   "npmName": "moment-timezone",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "moment-timezone*"
       ]

--- a/ajax/libs/moment.js/package.json
+++ b/ajax/libs/moment.js/package.json
@@ -10,7 +10,7 @@
       ]
     },
     {
-      "basePath": "/min/",
+      "basePath": "min",
       "files": [
         "moment*.js"
       ]

--- a/ajax/libs/motajs/package.json
+++ b/ajax/libs/motajs/package.json
@@ -24,7 +24,7 @@
   "npmName": "motajs",
   "npmFileMap": [
     {
-      "basePath": "/main/",
+      "basePath": "main",
       "files": [
         "*.css",
         "*.js",

--- a/ajax/libs/msl-client-browser/package.json
+++ b/ajax/libs/msl-client-browser/package.json
@@ -8,7 +8,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/FINRAOS/MSL.git",
-    "basePath": "/msl-client-browser/",
+    "basePath": "msl-client-browser",
     "files": [
       "appcontainer-driver.js",
       "appcontainer-driver.min.js",

--- a/ajax/libs/musicmetadata/package.json
+++ b/ajax/libs/musicmetadata/package.json
@@ -25,7 +25,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/leetreveil/musicmetadata.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "**/*"
     ]

--- a/ajax/libs/mvw-injection/package.json
+++ b/ajax/libs/mvw-injection/package.json
@@ -21,7 +21,7 @@
   "npmName": "mvw-injection",
   "npmFileMap": [
     {
-      "basePath": "dist/",
+      "basePath": "dist",
       "files": [
         "dependency-injection.js",
         "dependency-injection.min.js",

--- a/ajax/libs/myscript/package.json
+++ b/ajax/libs/myscript/package.json
@@ -20,7 +20,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/MyScript/MyScriptJS.git",
-    "basePath": "/dist/",
+    "basePath": "dist",
     "files": [
       "myscript.min.js",
       "myscript.min.js.map",

--- a/ajax/libs/nanobar/package.json
+++ b/ajax/libs/nanobar/package.json
@@ -19,7 +19,7 @@
   "npmName": "nanobar",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "nanobar.js",
         "nanobar.min.js"

--- a/ajax/libs/nanogallery/package.json
+++ b/ajax/libs/nanogallery/package.json
@@ -22,7 +22,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/Kris-B/nanoGALLERY.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "**/*"
     ]

--- a/ajax/libs/neo-async/package.json
+++ b/ajax/libs/neo-async/package.json
@@ -9,7 +9,7 @@
   "npmName": "neo-async",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*"
       ]

--- a/ajax/libs/ng-clip/package.json
+++ b/ajax/libs/ng-clip/package.json
@@ -3,7 +3,7 @@
   "npmName": "ng-clip",
   "npmFileMap": [
     {
-      "basePath": "/dest/",
+      "basePath": "dest",
       "files": [
         "*"
       ]

--- a/ajax/libs/ng-csv/package.json
+++ b/ajax/libs/ng-csv/package.json
@@ -3,7 +3,7 @@
   "npmName": "ng-csv",
   "npmFileMap": [
     {
-      "basePath": "/build/",
+      "basePath": "build",
       "files": [
         "*"
       ]

--- a/ajax/libs/ng-dialog/package.json
+++ b/ajax/libs/ng-dialog/package.json
@@ -11,7 +11,7 @@
   "npmName": "ng-dialog",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "css/ngDialog.css",
         "css/ngDialog.min.css",

--- a/ajax/libs/ng-flow/package.json
+++ b/ajax/libs/ng-flow/package.json
@@ -24,7 +24,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/flowjs/ng-flow.git",
-    "basePath": "/dist/",
+    "basePath": "dist",
     "files": [
       "*.js"
     ]

--- a/ajax/libs/ng-pdfviewer/package.json
+++ b/ajax/libs/ng-pdfviewer/package.json
@@ -17,7 +17,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/akrennmair/ng-pdfviewer.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "**/*"
     ]

--- a/ajax/libs/ng-showdown/package.json
+++ b/ajax/libs/ng-showdown/package.json
@@ -23,7 +23,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/showdownjs/ng-showdown.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "**/*"
     ]

--- a/ajax/libs/ng-slider/package.json
+++ b/ajax/libs/ng-slider/package.json
@@ -14,7 +14,7 @@
   "npmName": "ng-slider",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "**/*"
       ]

--- a/ajax/libs/ng-tags-input/package.json
+++ b/ajax/libs/ng-tags-input/package.json
@@ -21,7 +21,7 @@
   "npmName": "ng-tags-input",
   "npmFileMap": [
     {
-      "basePath": "/build/",
+      "basePath": "build",
       "files": [
         "*.js",
         "*.css"

--- a/ajax/libs/ngInfiniteScroll/package.json
+++ b/ajax/libs/ngInfiniteScroll/package.json
@@ -15,7 +15,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/sroze/ngInfiniteScroll.git",
-    "basePath": "build/",
+    "basePath": "build",
     "files": [
       "ng-infinite-scroll*.js"
     ]

--- a/ajax/libs/nomnoml/package.json
+++ b/ajax/libs/nomnoml/package.json
@@ -19,7 +19,7 @@
   "npmName": "nomnoml",
   "npmFileMap": [
     {
-      "basePath": "dist/",
+      "basePath": "dist",
       "files": [
         "**/*"
       ]

--- a/ajax/libs/notify/package.json
+++ b/ajax/libs/notify/package.json
@@ -11,7 +11,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/notifyjs/notifyjs.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "**/*"
     ]

--- a/ajax/libs/nuclear-js/package.json
+++ b/ajax/libs/nuclear-js/package.json
@@ -17,7 +17,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/optimizely/nuclear-js.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "**/*"
     ]

--- a/ajax/libs/numeral.js/package.json
+++ b/ajax/libs/numeral.js/package.json
@@ -15,7 +15,7 @@
   "npmName": "numeral",
   "npmFileMap": [
     {
-      "basePath": "/min/",
+      "basePath": "min",
       "files": [
         "numeral.min.js"
       ]

--- a/ajax/libs/nwmatcher/package.json
+++ b/ajax/libs/nwmatcher/package.json
@@ -13,7 +13,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/dperini/nwmatcher.git",
-    "basePath": "src/",
+    "basePath": "src",
     "files": [
       "nwmatcher*.js"
     ]

--- a/ajax/libs/ol3/package.json
+++ b/ajax/libs/ol3/package.json
@@ -13,7 +13,7 @@
   "npmName": "openlayers",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "**/*"
       ]

--- a/ajax/libs/omniscient/package.json
+++ b/ajax/libs/omniscient/package.json
@@ -15,7 +15,7 @@
   "npmName": "omniscient",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/onsen/package.json
+++ b/ajax/libs/onsen/package.json
@@ -26,7 +26,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/OnsenUI/OnsenUI.git",
-    "basePath": "build/",
+    "basePath": "build",
     "files": [
       "js/*",
       "css/*"

--- a/ajax/libs/opentype.js/package.json
+++ b/ajax/libs/opentype.js/package.json
@@ -20,7 +20,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/nodebox/opentype.js.git",
-    "basePath": "/dist/",
+    "basePath": "dist",
     "files": [
       "opentype.min.js",
       "opentype.js"

--- a/ajax/libs/operative/package.json
+++ b/ajax/libs/operative/package.json
@@ -7,7 +7,7 @@
   "npmName": "operative",
   "npmFileMap": [
     {
-      "basePath": "/dist",
+      "basePath": "dist",
       "files": [
         "*"
       ]

--- a/ajax/libs/orb/package.json
+++ b/ajax/libs/orb/package.json
@@ -22,7 +22,7 @@
   "npmName": "orb",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js",
         "*.css",

--- a/ajax/libs/ouibounce/package.json
+++ b/ajax/libs/ouibounce/package.json
@@ -12,7 +12,7 @@
   ],
   "npmFileMap": [
     {
-      "basePath": "/build/",
+      "basePath": "build",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/p2.js/package.json
+++ b/ajax/libs/p2.js/package.json
@@ -22,7 +22,7 @@
   "npmName": "p2",
   "npmFileMap": [
     {
-      "basePath": "/build/",
+      "basePath": "build",
       "files": [
         "*"
       ]

--- a/ajax/libs/packery/package.json
+++ b/ajax/libs/packery/package.json
@@ -14,7 +14,7 @@
   "npmName": "packery",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*"
       ]

--- a/ajax/libs/pangu/package.json
+++ b/ajax/libs/pangu/package.json
@@ -30,7 +30,7 @@
   "npmName": "pangu",
   "npmFileMap": [
     {
-      "basePath": "/dist/browser",
+      "basePath": "dist/browser",
       "files": [
         "**/*"
       ]

--- a/ajax/libs/parsley.js/package.json
+++ b/ajax/libs/parsley.js/package.json
@@ -11,7 +11,7 @@
   "npmName": "parsleyjs",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/peerjs/package.json
+++ b/ajax/libs/peerjs/package.json
@@ -11,7 +11,7 @@
   "npmName": "peerjs",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*"
       ]

--- a/ajax/libs/pickadate.js/package.json
+++ b/ajax/libs/pickadate.js/package.json
@@ -4,7 +4,7 @@
   "npmName": "pickadate",
   "npmFileMap": [
     {
-      "basePath": "/lib/",
+      "basePath": "lib",
       "files": [
         "*"
       ]

--- a/ajax/libs/picturefill/package.json
+++ b/ajax/libs/picturefill/package.json
@@ -14,7 +14,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/scottjehl/picturefill.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "*"
     ]

--- a/ajax/libs/pixi.js/package.json
+++ b/ajax/libs/pixi.js/package.json
@@ -15,7 +15,7 @@
   "npmName": "pixi.js",
   "npmFileMap": [
     {
-      "basePath": "/bin",
+      "basePath": "bin",
       "files": [
         "pixi.js",
         "pixi.dev.js"

--- a/ajax/libs/placeholders/package.json
+++ b/ajax/libs/placeholders/package.json
@@ -13,7 +13,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/jamesallardice/Placeholders.js.git",
-    "basePath": "/dist",
+    "basePath": "dist",
     "files": [
       "placeholders*.js"
     ]

--- a/ajax/libs/plastiq/package.json
+++ b/ajax/libs/plastiq/package.json
@@ -6,7 +6,7 @@
   "npmName": "angular-moment",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "plastiq.js",
         "plastiq.min.js"

--- a/ajax/libs/platform/package.json
+++ b/ajax/libs/platform/package.json
@@ -21,7 +21,7 @@
   "npmName": "platform",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "platform.js"
       ]

--- a/ajax/libs/playlyfe-js-sdk/package.json
+++ b/ajax/libs/playlyfe-js-sdk/package.json
@@ -25,7 +25,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/playlyfe/playlyfe-js-sdk.git",
-    "basePath": "/lib/",
+    "basePath": "lib",
     "files": [
       "playlyfe-js-sdk.js",
       "playlyfe-js-sdk.min.js"

--- a/ajax/libs/playlyfe-odysseus/package.json
+++ b/ajax/libs/playlyfe-odysseus/package.json
@@ -21,7 +21,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/playlyfe/odysseus.git",
-    "basePath": "/lib/",
+    "basePath": "lib",
     "files": [
       "odysseus.js",
       "odysseus.min.js"

--- a/ajax/libs/postal.js/package.json
+++ b/ajax/libs/postal.js/package.json
@@ -28,7 +28,7 @@
   "npmName": "postal",
   "npmFileMap": [
     {
-      "basePath": "/lib/",
+      "basePath": "lib",
       "files": [
         "postal.js",
         "postal.min.js",

--- a/ajax/libs/pouchdb/package.json
+++ b/ajax/libs/pouchdb/package.json
@@ -3,7 +3,7 @@
   "npmName": "pouchdb",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "pouchdb.js",
         "pouchdb.min.js"

--- a/ajax/libs/primish/package.json
+++ b/ajax/libs/primish/package.json
@@ -17,7 +17,7 @@
   "npmName": "primish",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "primish-min.js"
       ]

--- a/ajax/libs/probtn/package.json
+++ b/ajax/libs/probtn/package.json
@@ -15,7 +15,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/probtn/probtn-web.git",
-    "basePath": "/cdn/",
+    "basePath": "cdn",
     "files": [
       "**/*"
     ]

--- a/ajax/libs/proj4js/package.json
+++ b/ajax/libs/proj4js/package.json
@@ -10,7 +10,7 @@
   "npmName": "proj4",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/prostyle/package.json
+++ b/ajax/libs/prostyle/package.json
@@ -21,7 +21,7 @@
   "npmName": "prostyle",
   "npmFileMap": [
     {
-      "basePath": "/js/",
+      "basePath": "js",
       "files": [
         "*.min.js",
         "plus/*.min.js"

--- a/ajax/libs/pubsub-js/package.json
+++ b/ajax/libs/pubsub-js/package.json
@@ -15,7 +15,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/mroderick/PubSubJS.git",
-    "basePath": "src/",
+    "basePath": "src",
     "files": [
       "pubsub*.js"
     ]

--- a/ajax/libs/pusher-angular/package.json
+++ b/ajax/libs/pusher-angular/package.json
@@ -6,7 +6,7 @@
   "npmName": "pusher-angular",
   "npmFileMap": [
     {
-      "basePath": "/lib/",
+      "basePath": "lib",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/qoopido.js/package.json
+++ b/ajax/libs/qoopido.js/package.json
@@ -30,7 +30,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/dlueth/qoopido.js.git",
-    "basePath": "/dist/latest/min",
+    "basePath": "dist/latest/min",
     "files": [
       "**/*.js"
     ]

--- a/ajax/libs/queue-async/package.json
+++ b/ajax/libs/queue-async/package.json
@@ -19,7 +19,7 @@
   "npmName": "queue-async",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "queue.min.js",
         "queue.js"

--- a/ajax/libs/qwery/package.json
+++ b/ajax/libs/qwery/package.json
@@ -18,7 +18,7 @@
   "npmName": "qwery",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "qwery.js",
         "qwery.min.js"

--- a/ajax/libs/ractive-require/package.json
+++ b/ajax/libs/ractive-require/package.json
@@ -17,7 +17,7 @@
   "npmName": "ractive-require",
   "npmFileMap": [
     {
-      "basePath": "dist/",
+      "basePath": "dist",
       "files": [
         "ractive-require.js",
         "ractive-require.min.js",

--- a/ajax/libs/ractive/package.json
+++ b/ajax/libs/ractive/package.json
@@ -20,7 +20,7 @@
   "npmName": "ractive",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "ractive*.js",
         "ractive*.map"

--- a/ajax/libs/ramda/package.json
+++ b/ajax/libs/ramda/package.json
@@ -3,7 +3,7 @@
   "npmName": "ramda",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "ramda.js",
         "ramda.min.js"

--- a/ajax/libs/rangeslider.js/package.json
+++ b/ajax/libs/rangeslider.js/package.json
@@ -26,7 +26,7 @@
   "npmName": "rangeslider.js",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "**/*"
       ]

--- a/ajax/libs/react-bootstrap/package.json
+++ b/ajax/libs/react-bootstrap/package.json
@@ -14,7 +14,7 @@
   "npmName": "react-bootstrap",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "**/*"
       ]

--- a/ajax/libs/react-foundation-apps/package.json
+++ b/ajax/libs/react-foundation-apps/package.json
@@ -32,7 +32,7 @@
   "npmName": "react-foundation-apps",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/react-intl/package.json
+++ b/ajax/libs/react-intl/package.json
@@ -13,7 +13,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/yahoo/react-intl.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "**/*"
     ]

--- a/ajax/libs/react-modal/package.json
+++ b/ajax/libs/react-modal/package.json
@@ -24,7 +24,7 @@
   "npmName": "react-modal",
   "npmFileMap": [
     {
-      "basePath": "/dist",
+      "basePath": "dist",
       "files": [
         "**/*"
       ]

--- a/ajax/libs/react-redux/package.json
+++ b/ajax/libs/react-redux/package.json
@@ -24,7 +24,7 @@
   "npmName": "react-redux",
   "npmFileMap": [
     {
-      "basePath": "dist/",
+      "basePath": "dist",
       "files": [
         "**/*"
       ]

--- a/ajax/libs/react-router-redux/package.json
+++ b/ajax/libs/react-router-redux/package.json
@@ -19,7 +19,7 @@
   "npmName": "react-router-redux",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "**/*"
       ]

--- a/ajax/libs/react-slick/package.json
+++ b/ajax/libs/react-slick/package.json
@@ -26,7 +26,7 @@
   "npmName": "react-slick",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/ready.js/package.json
+++ b/ajax/libs/ready.js/package.json
@@ -17,7 +17,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/nouveller/ready.js.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "ready.min.js",
       "ready.js"

--- a/ajax/libs/redux/package.json
+++ b/ajax/libs/redux/package.json
@@ -30,7 +30,7 @@
   "npmName": "redux",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/requirejs-plugins/package.json
+++ b/ajax/libs/requirejs-plugins/package.json
@@ -6,7 +6,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/millermedeiros/requirejs-plugins.git",
-    "basePath": "/src/",
+    "basePath": "src",
     "files": [
       "*"
     ]

--- a/ajax/libs/reqwest/package.json
+++ b/ajax/libs/reqwest/package.json
@@ -21,7 +21,7 @@
   "npmName": "reqwest",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "reqwest.js",
         "reqwest.min.js"

--- a/ajax/libs/restangular/package.json
+++ b/ajax/libs/restangular/package.json
@@ -3,7 +3,7 @@
   "npmName": "restangular",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*"
       ]

--- a/ajax/libs/rickshaw/package.json
+++ b/ajax/libs/rickshaw/package.json
@@ -26,7 +26,7 @@
   "npmName": "rickshaw",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "rickshaw.css",
         "rickshaw.min.css",

--- a/ajax/libs/rivets/package.json
+++ b/ajax/libs/rivets/package.json
@@ -19,7 +19,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/mikeric/rivets.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "*.js"
     ]

--- a/ajax/libs/rxjs/package.json
+++ b/ajax/libs/rxjs/package.json
@@ -3,7 +3,7 @@
   "npmName": "@reactivex/rxjs",
   "npmFileMap": [
     {
-      "basePath": "/dist/global",
+      "basePath": "dist/global",
       "files": [
         "**/*"
       ]

--- a/ajax/libs/script.js/package.json
+++ b/ajax/libs/script.js/package.json
@@ -17,7 +17,7 @@
   "npmName": "scriptjs",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "script.min.js"
       ]

--- a/ajax/libs/seajs/package.json
+++ b/ajax/libs/seajs/package.json
@@ -18,7 +18,7 @@
   "npmName": "seajs",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*"
       ]

--- a/ajax/libs/seedrandom/package.json
+++ b/ajax/libs/seedrandom/package.json
@@ -3,7 +3,7 @@
   "npmName": "seedrandom",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "seedrandom.js",
         "seedrandom.min.js",

--- a/ajax/libs/select2-bootstrap-css/package.json
+++ b/ajax/libs/select2-bootstrap-css/package.json
@@ -7,7 +7,7 @@
   "npmName": "select2-bootstrap-css",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "*.css"
       ]

--- a/ajax/libs/set-iframe-height/package.json
+++ b/ajax/libs/set-iframe-height/package.json
@@ -3,7 +3,7 @@
   "npmName": "set-iframe-height",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/shaka-player/package.json
+++ b/ajax/libs/shaka-player/package.json
@@ -12,7 +12,7 @@
   "npmName": "shaka-player",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "shaka-player*"
       ]

--- a/ajax/libs/shariff/package.json
+++ b/ajax/libs/shariff/package.json
@@ -20,7 +20,7 @@
   "npmName": "shariff",
   "npmFileMap": [
     {
-      "basePath": "build/",
+      "basePath": "build",
       "files": [
         "shariff*.+(js|css)"
       ]

--- a/ajax/libs/shred/package.json
+++ b/ajax/libs/shred/package.json
@@ -13,7 +13,7 @@
   "npmName": "shred",
   "npmFileMap": [
     {
-      "basePath": "/lib/",
+      "basePath": "lib",
       "files": [
         "shred.js"
       ]

--- a/ajax/libs/sidr/package.json
+++ b/ajax/libs/sidr/package.json
@@ -15,7 +15,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/artberri/sidr.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "jquery.sidr.min.js",
       "stylesheets/jquery.sidr.dark.min.css",

--- a/ajax/libs/signature_pad/package.json
+++ b/ajax/libs/signature_pad/package.json
@@ -6,7 +6,7 @@
   "npmName": "signature_pad",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "signature_pad.js",
         "signature_pad.min.js"

--- a/ajax/libs/simple-statistics/package.json
+++ b/ajax/libs/simple-statistics/package.json
@@ -21,7 +21,7 @@
   "npmName": "simple-statistics",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "simple_statistics.min.js",
         "simple_statistics.js"

--- a/ajax/libs/sizzle/package.json
+++ b/ajax/libs/sizzle/package.json
@@ -3,7 +3,7 @@
   "npmName": "sizzle",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*"
       ]

--- a/ajax/libs/skrollr/package.json
+++ b/ajax/libs/skrollr/package.json
@@ -19,7 +19,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/Prinzhorn/skrollr.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "**/*"
     ]

--- a/ajax/libs/slick-carousel/package.json
+++ b/ajax/libs/slick-carousel/package.json
@@ -10,7 +10,7 @@
   "npmName": "slick-carousel",
   "npmFileMap": [
     {
-      "basePath": "/slick/",
+      "basePath": "slick",
       "files": [
         "fonts/slick.*",
         "*.js",

--- a/ajax/libs/sockjs-client/package.json
+++ b/ajax/libs/sockjs-client/package.json
@@ -10,7 +10,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/sockjs/sockjs-client.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "sockjs.min.js",
       "sockjs.js"

--- a/ajax/libs/soundplayer-widget/package.json
+++ b/ajax/libs/soundplayer-widget/package.json
@@ -26,7 +26,7 @@
   "npmName": "soundplayer-widget",
   "npmFileMap": [
     {
-      "basePath": "/dist",
+      "basePath": "dist",
       "files": [
         "**/*"
       ]

--- a/ajax/libs/spa.js/package.json
+++ b/ajax/libs/spa.js/package.json
@@ -17,7 +17,7 @@
   "npmName": "spa.js",
   "npmFileMap": [
     {
-      "basePath": "/dist",
+      "basePath": "dist",
       "files": [
         "**/*"
       ]

--- a/ajax/libs/speakingurl/package.json
+++ b/ajax/libs/speakingurl/package.json
@@ -63,7 +63,7 @@
   "npmName": "speakingurl",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "speakingurl.min.js"
       ]

--- a/ajax/libs/spf/package.json
+++ b/ajax/libs/spf/package.json
@@ -11,7 +11,7 @@
   "npmName": "spf",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*"
       ]

--- a/ajax/libs/sprintf/package.json
+++ b/ajax/libs/sprintf/package.json
@@ -3,7 +3,7 @@
   "npmName": "sprintf-js",
   "npmFileMap": [
     {
-      "basePath": "/src/",
+      "basePath": "src",
       "files": [
         "sprintf.js",
         "sprintf.min.js"

--- a/ajax/libs/sprite-js/package.json
+++ b/ajax/libs/sprite-js/package.json
@@ -18,7 +18,7 @@
   "npmName": "sprite-js",
   "npmFileMap": [
     {
-      "basePath": "/dist",
+      "basePath": "dist",
       "files": [
         "*"
       ]

--- a/ajax/libs/stacktrace.js/package.json
+++ b/ajax/libs/stacktrace.js/package.json
@@ -18,7 +18,7 @@
   "npmName": "stacktrace-js",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*"
       ]

--- a/ajax/libs/stapes/package.json
+++ b/ajax/libs/stapes/package.json
@@ -17,7 +17,7 @@
   "npmName": "stapes",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "stapes.js",
         "stapes.min.js"

--- a/ajax/libs/startbootstrap-sb-admin-2/package.json
+++ b/ajax/libs/startbootstrap-sb-admin-2/package.json
@@ -12,7 +12,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/BlackrockDigital/startbootstrap-sb-admin-2.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "js/sb-admin-2.js",
       "js/sb-admin-2.min.js",

--- a/ajax/libs/stomp.js/package.json
+++ b/ajax/libs/stomp.js/package.json
@@ -15,7 +15,7 @@
   "npmName": "stompjs",
   "npmFileMap": [
     {
-      "basePath": "/lib/",
+      "basePath": "lib",
       "files": [
         "stomp.js",
         "stomp.min.js"

--- a/ajax/libs/strapdown-topbar/package.json
+++ b/ajax/libs/strapdown-topbar/package.json
@@ -13,7 +13,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/joedf/strapdown-topbar.git",
-    "basePath": "assets/strapdown/",
+    "basePath": "assets/strapdown",
     "files": [
       "strapdown-topbar*"
     ]

--- a/ajax/libs/string.js/package.json
+++ b/ajax/libs/string.js/package.json
@@ -3,7 +3,7 @@
   "npmName": "string",
   "npmFileMap": [
     {
-      "basePath": "/lib/",
+      "basePath": "lib",
       "files": [
         "string.*"
       ]

--- a/ajax/libs/string_score/package.json
+++ b/ajax/libs/string_score/package.json
@@ -12,7 +12,7 @@
   "npmName": "string_score",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "string_score.js",
         "string_score.min.js"

--- a/ajax/libs/svg.draggy.js/package.json
+++ b/ajax/libs/svg.draggy.js/package.json
@@ -16,7 +16,7 @@
   "npmName": "svg.draggy.js",
   "npmFileMap": [
     {
-      "basePath": "/src",
+      "basePath": "src",
       "files": [
         "*"
       ]

--- a/ajax/libs/svg.pan-zoom.js/package.json
+++ b/ajax/libs/svg.pan-zoom.js/package.json
@@ -17,7 +17,7 @@
   "npmName": "svg.pan-zoom.js",
   "npmFileMap": [
     {
-      "basePath": "/src/",
+      "basePath": "src",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/swagger-ui/package.json
+++ b/ajax/libs/swagger-ui/package.json
@@ -15,7 +15,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/swagger-api/swagger-ui.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "swagger-ui.*",
       "css/screen.css",

--- a/ajax/libs/sweetalert/package.json
+++ b/ajax/libs/sweetalert/package.json
@@ -11,7 +11,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/t4t5/sweetalert.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "**/*"
     ]

--- a/ajax/libs/swig/package.json
+++ b/ajax/libs/swig/package.json
@@ -22,7 +22,7 @@
   "npmName": "swig",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "**/*"
       ]

--- a/ajax/libs/tabcomplete/package.json
+++ b/ajax/libs/tabcomplete/package.json
@@ -10,7 +10,7 @@
   "npmName": "tabcomplete",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "tabcomplete.js",
         "tabcomplete.min.js"

--- a/ajax/libs/tabletop.js/package.json
+++ b/ajax/libs/tabletop.js/package.json
@@ -14,7 +14,7 @@
   "npmName": "tabletop",
   "npmFileMap": [
     {
-      "basePath": "/src/",
+      "basePath": "src",
       "files": [
         "tabletop.js",
         "backbone.tabletopSync.js"

--- a/ajax/libs/taffydb/package.json
+++ b/ajax/libs/taffydb/package.json
@@ -19,7 +19,7 @@
   "npmName": "taffydb",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "taffy.js",
         "taffy-min.js"

--- a/ajax/libs/templatebinding/package.json
+++ b/ajax/libs/templatebinding/package.json
@@ -3,7 +3,7 @@
   "npmName": "templatebinding",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "TemplateBinding.min.js",
         "TemplateBinding.js"

--- a/ajax/libs/textAngular/package.json
+++ b/ajax/libs/textAngular/package.json
@@ -13,7 +13,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/fraywing/textAngular.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "**/*"
     ]

--- a/ajax/libs/then-request/package.json
+++ b/ajax/libs/then-request/package.json
@@ -15,7 +15,7 @@
   "npmName": "then-request",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*"
       ]

--- a/ajax/libs/timecircles/package.json
+++ b/ajax/libs/timecircles/package.json
@@ -25,7 +25,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/wimbarelds/TimeCircles.git",
-    "basePath": "inc/",
+    "basePath": "inc",
     "files": [
       "TimeCircles*"
     ]

--- a/ajax/libs/tinymce/package.json
+++ b/ajax/libs/tinymce/package.json
@@ -12,7 +12,7 @@
   "npmName": "tinymce",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "tinymce.min.js",
         "tinymce.jquery.min.js",

--- a/ajax/libs/twitter-bootstrap/package.json
+++ b/ajax/libs/twitter-bootstrap/package.json
@@ -4,7 +4,7 @@
   "npmName": "bootstrap",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*"
       ]

--- a/ajax/libs/typeahead.js/package.json
+++ b/ajax/libs/typeahead.js/package.json
@@ -12,7 +12,7 @@
   "npmName": "typeahead.js",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/typed.js/package.json
+++ b/ajax/libs/typed.js/package.json
@@ -15,7 +15,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/mattboldt/typed.js.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "**/*"
     ]

--- a/ajax/libs/typescript/package.json
+++ b/ajax/libs/typescript/package.json
@@ -18,7 +18,7 @@
   "npmName": "typescript",
   "npmFileMap": [
     {
-      "basePath": "lib/",
+      "basePath": "lib",
       "files": [
         "typescript.js"
       ]

--- a/ajax/libs/typicons/package.json
+++ b/ajax/libs/typicons/package.json
@@ -14,7 +14,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/stephenhutchings/typicons.font.git",
-    "basePath": "src/font/",
+    "basePath": "src/font",
     "files": [
       "*.ttf",
       "*.eot",

--- a/ajax/libs/underscore-contrib/package.json
+++ b/ajax/libs/underscore-contrib/package.json
@@ -20,7 +20,7 @@
   "npmName": "underscore-contrib",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*"
       ]

--- a/ajax/libs/unsemantic/package.json
+++ b/ajax/libs/unsemantic/package.json
@@ -13,7 +13,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/nathansmith/unsemantic.git",
-    "basePath": "assets/stylesheets/",
+    "basePath": "assets/stylesheets",
     "files": [
       "unsemantic-grid*.css"
     ]

--- a/ajax/libs/upb/package.json
+++ b/ajax/libs/upb/package.json
@@ -19,13 +19,13 @@
   "npmName": "upb",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "upb.js"
       ]
     },
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         ".js",
         ".map"

--- a/ajax/libs/urljs/package.json
+++ b/ajax/libs/urljs/package.json
@@ -17,7 +17,7 @@
   "npmName": "urljs",
   "npmFileMap": [
     {
-      "basePath": "/src/",
+      "basePath": "src",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/usertiming/package.json
+++ b/ajax/libs/usertiming/package.json
@@ -19,7 +19,7 @@
   "npmName": "usertiming",
   "npmFileMap": [
     {
-      "basePath": "/dist",
+      "basePath": "dist",
       "files": [
         "**/*"
       ]

--- a/ajax/libs/validatorjs/package.json
+++ b/ajax/libs/validatorjs/package.json
@@ -17,7 +17,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/ppoffice/validator.js.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "**/*"
     ]

--- a/ajax/libs/vault.js/package.json
+++ b/ajax/libs/vault.js/package.json
@@ -22,7 +22,7 @@
   "npmName": "vault.js",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/vega/package.json
+++ b/ajax/libs/vega/package.json
@@ -11,7 +11,7 @@
   "npmName": "vega",
   "npmFileMap": [
     {
-      "basePath": "/",
+      "basePath": "",
       "files": [
         "vega.js",
         "vega.min.js"

--- a/ajax/libs/vegas/package.json
+++ b/ajax/libs/vegas/package.json
@@ -17,7 +17,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/jaysalvat/vegas.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "**/*"
     ]

--- a/ajax/libs/velocity/package.json
+++ b/ajax/libs/velocity/package.json
@@ -9,7 +9,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/julianshapiro/velocity.git",
-    "basePath": "/",
+    "basePath": "",
     "files": [
       "velocity.js",
       "velocity.min.js",

--- a/ajax/libs/videomail-client/package.json
+++ b/ajax/libs/videomail-client/package.json
@@ -17,7 +17,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/binarykitchen/videomail-client.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "**/*"
     ]

--- a/ajax/libs/virtual-keyboard/package.json
+++ b/ajax/libs/virtual-keyboard/package.json
@@ -30,7 +30,7 @@
   "npmName": "virtual-keyboard",
   "npmFileMap": [
     {
-      "basePath": "dist/",
+      "basePath": "dist",
       "files": [
         "**/*"
       ]

--- a/ajax/libs/websqltracer/package.json
+++ b/ajax/libs/websqltracer/package.json
@@ -14,7 +14,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/terikon/webSqlTracer.git",
-    "basePath": "/dist/",
+    "basePath": "dist",
     "files": [
       "webSqlTracer.min.js",
       "webSqlTracer.min.js.map"

--- a/ajax/libs/whereyat/package.json
+++ b/ajax/libs/whereyat/package.json
@@ -3,7 +3,7 @@
   "npmName": "whereyat",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/wow/package.json
+++ b/ajax/libs/wow/package.json
@@ -17,7 +17,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/matthieua/WOW.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "*"
     ]

--- a/ajax/libs/xdomain/package.json
+++ b/ajax/libs/xdomain/package.json
@@ -12,7 +12,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/jpillora/xdomain.git",
-    "basePath": "dist/",
+    "basePath": "dist",
     "files": [
       "*"
     ]

--- a/ajax/libs/xls/package.json
+++ b/ajax/libs/xls/package.json
@@ -3,7 +3,7 @@
   "npmName": "xlsjs",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js",
         "*.map"

--- a/ajax/libs/xlsx/package.json
+++ b/ajax/libs/xlsx/package.json
@@ -3,7 +3,7 @@
   "npmName": "xlsx",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.js",
         "*.map"

--- a/ajax/libs/yasgui/package.json
+++ b/ajax/libs/yasgui/package.json
@@ -19,7 +19,7 @@
   "npmName": "yasgui",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.min.js",
         "*.min.js.map",

--- a/ajax/libs/yasqe/package.json
+++ b/ajax/libs/yasqe/package.json
@@ -19,7 +19,7 @@
   "npmName": "yasgui-yasqe",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.min.js",
         "*.min.js.map",

--- a/ajax/libs/yasr/package.json
+++ b/ajax/libs/yasr/package.json
@@ -19,7 +19,7 @@
   "npmName": "yasgui-yasr",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "*.min.js",
         "*.min.js.map",

--- a/ajax/libs/zeroclipboard/package.json
+++ b/ajax/libs/zeroclipboard/package.json
@@ -22,7 +22,7 @@
   "npmName": "zeroclipboard",
   "npmFileMap": [
     {
-      "basePath": "/dist/",
+      "basePath": "dist",
       "files": [
         "ZeroClipboard.*"
       ]

--- a/ajax/libs/zurb-ink/package.json
+++ b/ajax/libs/zurb-ink/package.json
@@ -14,7 +14,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/zurb/ink.git",
-    "basePath": "css/",
+    "basePath": "css",
     "files": [
       "ink.css"
     ]

--- a/test/valid-packages-test.js
+++ b/test/valid-packages-test.js
@@ -281,6 +281,32 @@ packages.map(function(pkg) {
                   pkgName(pkg) + ": Need to add \"String\" type basePath in auto-update config");
     }
   }
+  packageVows[pname + ": There must no \"/\" at the front or the last of basePath "] = function(pkg) {
+    var json = parse(pkg, true);
+    if (json.npmFileMap) {
+      for (var i in json.npmFileMap) {
+        if (json.npmFileMap[i].basePath) {
+          var basePath = json.npmFileMap[i].basePath;
+          assert.ok(
+             (
+                 (basePath.length == 0) ||
+                 (basePath[0] != '/' && basePath[basePath.length-1] != '/')
+             ),
+             pkgName(pkg) + ": Need to remove \"/\" at the front or the last of basePath in package.json");
+        }
+      }
+    } else if (json.autoupdate) {
+        if (json.autoupdate.basePath) {
+          var basePath = json.autoupdate.basePath;
+            assert.ok(
+                (
+                    (basePath.length == 0) ||
+                    (basePath[0] != '/' && basePath[basePath.length-1] != '/')
+                ),
+                pkgName(pkg) + ": Need to remove \"/\" at the front or the last of basePath in package.json");
+        }
+      }
+  };
   context[pname] = packageVows;
   suite.addBatch(context);
   return null;

--- a/tools/fixFormat.js
+++ b/tools/fixFormat.js
@@ -67,6 +67,22 @@ async.each(packages, function(item, callback) {
     pkg.licenses = pkg.license;
     delete pkg.license;
   }
+  if (pkg.npmFileMap) {
+    for (var i in pkg.npmFileMap) {
+      var npmbasePath = pkg.npmFileMap[i].basePath;
+      if (npmbasePath && npmbasePath.length != 0 && ((typeof npmbasePath) == "string")) {
+          npmbasePath = (npmbasePath).replace(/^\/+|\/+$/g , "");
+          pkg.npmFileMap[i].basePath = npmbasePath;
+      }
+    }
+  }
+  if (pkg.autoupdate) {
+    var basePath = pkg.autoupdate.basePath;
+    if (basePath && basePath.length != 0 && ((typeof basePath) == "string")) {
+        basePath = (basePath).replace(/^\/+|\/+$/g , "");
+        pkg.autoupdate.basePath = basePath;
+    }
+  }
   fs.writeFileSync(item, JSON.stringify(pkg, null, 2) + '\n', 'utf8');
   callback();
 });


### PR DESCRIPTION
PR to fix basePath with leading and trailing slash in auto-update 
cc @PeterDaveHello 

Affected 434 libs as follow:

- 16pixels
- absurd
- accounting.js
- ajile
- alasql
- algoliasearch
- allow-me
- ally.js
- analytics.js
- angular-autofields
- angular-azure-mobile-service
- angular-busy
- angular-cache
- angular-css
- angular-data
- angular-dialog-service
- angular-filter
- angular-formly-templates-bootstrap
- angular-formly
- angular-gravatar
- angular-highlightjs
- angular-i18n
- angular-leaflet-directive
- angular-local-storage
- angular-material
- angular-material-icons
- angular-materialize
- angular-md5
- angular-moment
- angular-nvd3
- angular-recaptcha
- angular-retina
- angular-route-segment
- angular-schema-form
- angular-spinner
- angular-strap
- angular-ui-router
- angular-ui-tree
- angular-vertxbus
- angular-wizard
- angular-xeditable
- angulartics-google-analytics
- AniJS
- anima
- annyang
- api-check
- architect
- atmosphere
- audio5js
- autocomplete.js
- awesome-bootstrap-checkbox
- backbone-associations
- backbone-forms
- backbone-localstorage.js
- backbone-pageable
- backbone-react-component
- backbone-relational
- backbone.babysitter
- backbone.collectionView
- backbone.js
- backbone.layoutmanager
- backbone.validation
- bacon.js
- barn
- Base64
- basis.js
- basket.js
- bean
- benchmark
- bespoke.js
- bignumber.js
- bla
- blueimp-gallery
- blueimp-md5
- bootcards
- bootstrap-confirmation
- bootstrap-markdown
- bootstrap-select
- bootstrap-slider
- bootstrap-switch
- bootstrap-table
- bootstrap-tokenfield
- bootstrap-tour
- bricklayer
- bttrlazyloading
- caiuss
- camanjs
- cannon.js
- catiline
- chai
- chainloading
- chardin.js
- chroma-js
- cldrjs
- clipboard.js
- codemirror
- coffee-script
- Colors.js
- componentjs
- condition
- Cookies.js
- crel
- crossfilter
- cubism
- custom-elements-builder
- cutjs
- d3-geo-projection
- d3plus
- dancer.js
- danialfarid-angular-file-upload
- dat-gui
- dc
- depot
- device.js
- Director
- diva.js
- document-register-element
- dom4
- domainr-search-box
- domplotter
- draggabilly
- dropzone
- dustjs-helpers
- dustjs-linkedin
- eddy
- ekko-lightbox
- elasticsearch
- ember-dialog
- ember-i18n
- emblem
- es5-shim
- eve.js
- evil-icons
- fast-json-patch
- flickity
- floatthead
- fotorama
- free-jqgrid
- fullcalendar
- function-plot
- furtive
- fuse.js
- galleria
- geojs
- geojson2svg
- gh.js
- github-org-members.js
- gl-matrix
- golden-layout
- gorillascript
- grd
- gridly
- gsap
- Han
- handjs
- handlebars.js
- headhesive
- hiw-api
- horsey
- hprose-html5
- html5media
- hydra.js
- ICanHaz.js
- ice
- idbwrapper
- ie8
- iframe-resizer
- immstruct
- immutable
- ink
- insightjs
- intl-tel-input
- intro.js
- jcarousel
- jinplace
- jit
- jmpress
- jplayer
- jquery-bootgrid
- jquery-browser
- jquery-data-remote
- jquery-form-serializer
- jquery-image-upload
- jquery-impromptu
- jquery-jgrowl
- jquery-json-editor
- jquery-jsonview
- jquery-lazyload-any
- jquery-maskmoney
- jquery-migrate
- jquery-mobile
- jquery-noty
- jquery-once
- jquery-prompt21
- jquery-searcher
- jquery-sidebar
- jquery-smoove
- jquery-sortable
- jquery-ui-timepicker-addon
- jquery.age
- jquery.allowed-chars
- jquery.bootstrapvalidator
- jquery.devbridge-autocomplete
- jquery.fancytree
- jquery.formset
- jquery.gridster
- jquery.hashcash.io
- jquery.imagesloaded
- jquery.isotope
- jquery.lazyloadxt
- jquery.nanoscroller
- jquery.panzoom
- jquery.photocols
- jquery.postcodify
- jquery.simpleWeather
- jquery.smartmenus
- jquery.textcomplete
- jquery.tipsy
- jquery.ui-contextmenu
- jqueryui-touch-punch
- js-bson
- js-data-angular
- js-data-firebase
- js-data-http
- js-data-localforage
- js-data-localstorage
- js-sequence-diagrams
- jsface
- jsfeat
- jsforce
- jshint
- json3
- jsonld
- jsonlint
- jss
- jssip
- jssor-slider
- jstree
- jszip
- justifiedGallery
- jxon
- kartograph-js
- kineticjs
- klass
- knockback
- knockout-paging
- knockout-pre-rendered
- knockout-validation
- knockout
- kwargsjs
- Ladda
- layzr.js
- leaflet-dvf
- leaflet-hash
- Leaflet.awesome-markers
- leaflet.markercluster
- leaflet
- leapjs
- legojs
- less.js
- libil
- lightcase
- list.js
- list.pagination.js
- localforage
- localStorage
- loglevel
- lunr.js
- lz-string
- m8tro-bootstrap
- machina.js
- maquette
- markdown.js
- matreshka
- medium-editor-custom-html
- metisMenu
- mindb
- mini-meteor
- minicart
- minitranslate
- mithril
- mo
- mocha
- mojio-js
- moment-duration-format
- moment-range
- moment-timezone
- moment.js
- motajs
- msl-client-browser
- musicmetadata
- mvw-injection
- myscript
- nanobar
- nanogallery
- neo-async
- ng-clip
- ng-csv
- ng-dialog
- ng-flow
- ng-pdfviewer
- ng-showdown
- ng-slider
- ng-tags-input
- ngInfiniteScroll
- nomnoml
- notify
- nuclear-js
- numeral.js
- nwmatcher
- ol3
- omniscient
- onsen
- opentype.js
- operative
- orb
- ouibounce
- p2.js
- packery
- pangu
- parsley.js
- peerjs
- pickadate.js
- picturefill
- PikaChoose
- pixi.js
- placeholders
- plastiq
- platform
- playlyfe-js-sdk
- playlyfe-odysseus
- postal.js
- pouchdb
- primish
- probtn
- proj4js
- prostyle
- pubsub-js
- pusher-angular
- qoopido.js
- queue-async
- qwery
- ractive-require
- ractive
- ramda
- rangeslider.js
- react-bootstrap
- react-foundation-apps
- react-intl
- react-modal
- react-redux
- react-router-redux
- react-slick
- ready.js
- redux
- requirejs-plugins
- reqwest
- restangular
- rickshaw
- rivets
- rxjs
- script.js
- ScrollMagic
- seajs
- seedrandom
- select2-bootstrap-css
- set-iframe-height
- shaka-player
- shariff
- shred
- sidr
- signature_pad
- simple-statistics
- sizzle
- skrollr
- slick-carousel
- sockjs-client
- soundplayer-widget
- spa.js
- speakingurl
- spf
- sprintf
- sprite-js
- stacktrace.js
- stapes
- startbootstrap-sb-admin-2
- stomp.js
- strapdown-topbar
- string_score
- string.js
- SVG-Morpheus
- svg.draggy.js
- svg.pan-zoom.js
- swagger-ui
- sweetalert
- swig
- Swiper
- tabcomplete
- tabletop.js
- taffydb
- templatebinding
- textAngular
- then-request
- timecircles
- tinymce
- twitter-bootstrap
- typeahead.js
- typed.js
- typescript
- typicons
- UAParser.js
- underscore-contrib
- unsemantic
- upb
- urljs
- usertiming
- validatorjs
- vault.js
- vega
- vegas
- velocity
- videomail-client
- virtual-keyboard
- websqltracer
- whereyat
- wow
- xdomain
- xls
- xlsx
- yasgui
- yasqe
- yasr
- zeroclipboard
- zurb-ink