### PR TITLE
add and update basePath in auto-update for some libs

### DIFF
--- a/ajax/libs/FileSaver.js/package.json
+++ b/ajax/libs/FileSaver.js/package.json
@@ -15,6 +15,7 @@
   "npmName": "file-saver",
   "npmFileMap": [
     {
+      "basePath": "",
       "files": [
         "FileSaver*.js"
       ]

--- a/ajax/libs/bootstrap-notify/package.json
+++ b/ajax/libs/bootstrap-notify/package.json
@@ -16,6 +16,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/goodybag/bootstrap-notify.git",
+    "basePath": "",
     "files": [
       "css/styles/alert-*.css",
       "css/bootstrap-notify*.css",

--- a/ajax/libs/es6-shim/package.json
+++ b/ajax/libs/es6-shim/package.json
@@ -24,6 +24,7 @@
   "npmName": "es6-shim",
   "npmFileMap": [
     {
+      "basePath": "",
       "files": [
         "*.min.js",
         "es6-shim.*",

--- a/ajax/libs/flexslider/package.json
+++ b/ajax/libs/flexslider/package.json
@@ -11,7 +11,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/woothemes/FlexSlider.git",
-    "basepath": "",
+    "basePath": "",
     "files": [
       "flexslider.css",
       "jquery.flexslider-min.js",

--- a/ajax/libs/jquery-visibility/package.json
+++ b/ajax/libs/jquery-visibility/package.json
@@ -23,6 +23,7 @@
   "npmName": "jquery-visibility",
   "npmFileMap": [
     {
+      "basePath": "",
       "files": [
         "jquery-visibility*.js"
       ]

--- a/ajax/libs/mori/package.json
+++ b/ajax/libs/mori/package.json
@@ -3,6 +3,7 @@
   "npmName": "mori",
   "npmFileMap": [
     {
+      "basePath": "",
       "files": [
         "mori.js"
       ]

--- a/ajax/libs/portal/package.json
+++ b/ajax/libs/portal/package.json
@@ -16,6 +16,7 @@
   "npmName": "portal-client",
   "npmFileMap": [
     {
+      "basePath": "",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/processing.js/package.json
+++ b/ajax/libs/processing.js/package.json
@@ -11,6 +11,7 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/processing-js/processing-js.git",
+    "basePath": "",
     "files": [
       "processing.min.js",
       "processing.js"

--- a/ajax/libs/punycode/package.json
+++ b/ajax/libs/punycode/package.json
@@ -7,6 +7,7 @@
   "npmName": "punycode",
   "npmFileMap": [
     {
+      "basePath": "",
       "files": [
         "*.js"
       ]

--- a/ajax/libs/q.js/package.json
+++ b/ajax/libs/q.js/package.json
@@ -3,6 +3,7 @@
   "npmName": "q",
   "npmFileMap": [
     {
+      "basePath": "",
       "files": [
         "q.js"
       ]

--- a/test/valid-packages-test.js
+++ b/test/valid-packages-test.js
@@ -269,6 +269,18 @@ packages.map(function(pkg) {
                 pkgName(pkg) + ": Need to add repository information in package.json");
     }
   };
+  packageVows[pname + ": There must be \"String\" type basePath in auto-update config"] = function(pkg) {
+    var json = parse(pkg, true);
+    if (json.npmFileMap) {
+      for (var i in json.npmFileMap) {
+        assert.ok(json.npmFileMap[i].basePath != undefined && ((typeof json.npmFileMap[i].basePath) == "string"),
+                  pkgName(pkg) + ": Need to add \"String\" type basePath in auto-update config");
+      }
+    } else if (json.autoupdate) {
+        assert.ok(json.autoupdate.basePath != undefined && ((typeof json.autoupdate.basePath) == "string"),
+                  pkgName(pkg) + ": Need to add \"String\" type basePath in auto-update config");
+    }
+  }
   context[pname] = packageVows;
   suite.addBatch(context);
   return null;


### PR DESCRIPTION
PR to 
- add and update basePath in auto-update for some libs  
Affected 10 libs as follow:
 - bootstrap-notify
 - es6-shim
 - FileSaver.js
 - flexslider
 - jquery-visibility
 - mori
 - portal
 -  processing.js
 - punycode
 - q.js
- add test to check basePath in auto-update

cc @PeterDaveHello , cc #9192 

