### PR TITLE
Update autoupdate basePath in annyang

### DIFF
--- a/ajax/libs/annyang/package.json
+++ b/ajax/libs/annyang/package.json
@@ -24,7 +24,7 @@
     "target": "git://github.com/TalAter/annyang.git",
     "basePath": "dist/",
     "files": [
-      "*"
+      "**/*"
     ]
   }
 }

--- a/ajax/libs/annyang/package.json
+++ b/ajax/libs/annyang/package.json
@@ -22,10 +22,9 @@
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/TalAter/annyang.git",
-    "basePath": "",
+    "basePath": "dist/",
     "files": [
-      "annyang.min.js",
-      "annyang.js"
+      "*"
     ]
   }
 }


### PR DESCRIPTION
Updating existing library after directory structure change.

Files used to be in root directory, now they are in [`dist/`](https://github.com/TalAter/annyang/tree/master/dist)