### PR TITLE
Add license info of wordcloud2.js, cc #5500

### DIFF
--- a/ajax/libs/wordcloud2.js/package.json
+++ b/ajax/libs/wordcloud2.js/package.json
@@ -18,6 +18,7 @@
     "presentation",
     "tag"
   ],
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/timdream/wordcloud2.js"


### PR DESCRIPTION
Reference:
https://github.com/timdream/wordcloud2.js/blob/0606e894731cb6f6fa2fda36dce348cd4f2d8e97/LICENSE