### PR TITLE
Update license and remove homepage of viz.js

### DIFF
--- a/ajax/libs/viz.js/package.json
+++ b/ajax/libs/viz.js/package.json
@@ -12,7 +12,7 @@
     "type": "git",
     "url": "git://github.com/mdaines/viz.js"
   },
-  "license": "MIT",
+  "license": "Unlicense",
   "keywords": [
     "GraphViz",
     "viz"

--- a/ajax/libs/viz.js/package.json
+++ b/ajax/libs/viz.js/package.json
@@ -3,7 +3,6 @@
   "filename": "viz.js",
   "version": "1.3.0",
   "description": "A hack to put Graphviz on the web.",
-  "homepage": "https://github.com/mdaines/viz.js/",
   "author": {
     "name": "Mike Daines",
     "url": "https://github.com/mdaines"


### PR DESCRIPTION
PR for #8527 
- update license from MIT -> Unlicense
- remove homepage point to github repo in pakcage.json

@kennynaoh @x09326 Please help me review this pull request, thank you.

close #8527