### PR TITLE
Fix angular-deckgrid keyword typo

### DIFF
--- a/ajax/libs/angular-deckgrid/package.json
+++ b/ajax/libs/angular-deckgrid/package.json
@@ -3,7 +3,7 @@
   "description": "A lightweight masonry-like grid for AngularJS.",
   "author": "André König (andre.koenig@posteo.de)",
   "keywords": [
-    "deckgrind",
+    "deckgrid",
     "angular",
     "masonry",
     "grid"


### PR DESCRIPTION
I am just fixing a typo