### PR TITLE
Add license info of clientside-haml-js, cc #5500

### DIFF
--- a/ajax/libs/clientside-haml-js/package.json
+++ b/ajax/libs/clientside-haml-js/package.json
@@ -10,5 +10,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/uglyog/clientside-haml-js.git"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
Reference:
https://github.com/uglyog/clientside-haml-js/commit/d15512fcb102d5387cd680f634689b4bb9cccd9f