### PR TITLE
include inlite theme for tinymce

### DIFF
--- a/ajax/libs/tinymce/package.json
+++ b/ajax/libs/tinymce/package.json
@@ -18,6 +18,7 @@
         "tinymce.jquery.min.js",
         "jquery.tinymce.min.js",
         "themes/modern/theme.min.js",
+        "themes/inlite/theme.min.js",
         "skins/lightgray/*.css",
         "skins/lightgray/img/*",
         "skins/lightgray/fonts/*",


### PR DESCRIPTION
for tinyMCE the "inlite" theme is missing
tinymce docs: https://www.tinymce.com/docs/demo/inlite/