### PR TITLE
Add license to  hiw-api, cc#9248

### DIFF
--- a/ajax/libs/hiw-api/package.json
+++ b/ajax/libs/hiw-api/package.json
@@ -29,4 +29,5 @@
     "type": "git",
     "url": "git://github.com/HealthIndicators/js-api.git"
   }
+  "license": "MIT"
 }


### PR DESCRIPTION
https://github.com/HealthIndicators/js-api/blob/master/LICENSE.md