### PR TITLE
Add license of screenfull.js, cc #9248

### DIFF
--- a/ajax/libs/screenfull.js/package.json
+++ b/ajax/libs/screenfull.js/package.json
@@ -19,5 +19,6 @@
   "repository": {
     "type": "github",
     "url": "https://github.com/sindresorhus/screenfull.js"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
https://github.com/sindresorhus/screenfull.js/blob/gh-pages/license
