### PR TITLE
Add license info of videojs-contrib-dash, cc #5500

### DIFF
--- a/ajax/libs/videojs-contrib-dash/package.json
+++ b/ajax/libs/videojs-contrib-dash/package.json
@@ -8,6 +8,7 @@
   },
   "version": "2.5.1",
   "author": "Brightcove",
+  "license": "Apache-2.0",
   "keywords": [
     "video.js",
     "dash.js",


### PR DESCRIPTION
References:
https://github.com/videojs/videojs-contrib-dash/blob/master/LICENSE