### PR TITLE
Update package.json for just-animate

### DIFF
--- a/ajax/libs/just-animate/package.json
+++ b/ajax/libs/just-animate/package.json
@@ -15,7 +15,7 @@
     "waapi"
   ],
   "license": "MIT",
-  "homepage": "http://just-animate.com",
+  "homepage": "http://just-animate.com/",
   "repository": {
     "type": "git",
     "url": "https://github.com/just-animate/just-animate"

--- a/ajax/libs/just-animate/package.json
+++ b/ajax/libs/just-animate/package.json
@@ -2,7 +2,7 @@
   "name": "just-animate",
   "filename": "just-animate-all.min.js",
   "author": "Christopher Wallis <christopher.j.wallis@gmail.com>",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Web Animation library",
   "keywords": [
     "webanimation",

--- a/ajax/libs/just-animate/package.json
+++ b/ajax/libs/just-animate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "just-animate",
-  "filename": "just-animate-animations.min.js",
+  "filename": "just-animate-all.min.js",
   "author": "Christopher Wallis <christopher.j.wallis@gmail.com>",
   "version": "1.0.2",
   "description": "Web Animation library",
@@ -11,10 +11,11 @@
     "javascript",
     "animation",
     "timeline",
-    "sequence"
+    "sequence",
+    "waapi"
   ],
   "license": "MIT",
-  "homepage": "https://just-animate.github.io/",
+  "homepage": "http://just-animate.com",
   "repository": {
     "type": "git",
     "url": "https://github.com/just-animate/just-animate"
@@ -22,7 +23,7 @@
   "npmName": "just-animate",
   "npmFileMap": [
     {
-      "basePath": "browser",
+      "basePath": "dist",
       "files": [
         "**/!(*.ts)"
       ]


### PR DESCRIPTION
- updated website link
- updated folder structure; will be moved to dist from browser folder when I publish 1.1.0
- changed filename to just-animate-all.min.js (the current filename doesn't point to the actual lib)