### PR TITLE
Correct license typo of jquery.tipsy

### DIFF
--- a/ajax/libs/jquery.tipsy/package.json
+++ b/ajax/libs/jquery.tipsy/package.json
@@ -32,5 +32,5 @@
       ]
     }
   ],
-  "license": "MIT"
+  "license": "MIT" 
 }

--- a/ajax/libs/jquery.tipsy/package.json
+++ b/ajax/libs/jquery.tipsy/package.json
@@ -32,5 +32,5 @@
       ]
     }
   ],
-  "license": "MIT" 
+  "license": "MIT"
 }

--- a/ajax/libs/jquery.tipsy/package.json
+++ b/ajax/libs/jquery.tipsy/package.json
@@ -32,5 +32,5 @@
       ]
     }
   ],
-  "licencse": "MIT"
+  "license": "MIT"
 }


### PR DESCRIPTION
cc #9248, cc @x09326