### PR TITLE
[Author] Change viz.js license to MIT

### DIFF
--- a/ajax/libs/viz.js/package.json
+++ b/ajax/libs/viz.js/package.json
@@ -11,7 +11,7 @@
     "type": "git",
     "url": "git://github.com/mdaines/viz.js"
   },
-  "license": "Unlicense",
+  "license": "MIT",
   "keywords": [
     "GraphViz",
     "viz"


### PR DESCRIPTION
I've decided to license this project under the MIT license instead. See https://github.com/mdaines/viz.js/blob/master/LICENSE and #8527