### PR TITLE
Fix the spelling typo of jquery-replacetext "licenses"

### DIFF
--- a/ajax/libs/jquery-replace-text/package.json
+++ b/ajax/libs/jquery-replace-text/package.json
@@ -14,7 +14,7 @@
     "type": "git",
     "url": "https://github.com/cowboy/jquery-replacetext"
   },
-  "licences": [
+  "licenses": [
     "MIT",
     "GPL-2.0"
   ],


### PR DESCRIPTION
Modified the spelling error of "licences".