### PR TITLE
Add license info of jquery.finderselect, cc #5500

### DIFF
--- a/ajax/libs/jquery.finderselect/package.json
+++ b/ajax/libs/jquery.finderselect/package.json
@@ -15,5 +15,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/evulse/finderselect"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION

Reference: https://github.com/evulse/finderSelect/blob/master/LICENSE.txt