### PR TITLE
Reveal.js: add HTML files from plugins and switch to npm auto-update.

### DIFF
--- a/ajax/libs/reveal.js/package.json
+++ b/ajax/libs/reveal.js/package.json
@@ -10,25 +10,23 @@
     "presentations",
     "slides"
   ],
-  "autoupdate": {
-    "source": "git",
-    "target": "git://github.com/hakimel/reveal.js.git",
-    "fileMap": [
-      {
-        "basePath": "",
-        "files": [
-          "css/**/*.css",
-          "js/*.js",
-          "lib/**/*.js",
-          "lib/**/*.css",
-          "lib/**/*.eot",
-          "lib/**/*.ttf",
-          "lib/**/*.woff",
-          "plugin/**/*.js"
-        ]
-      }
-    ]
-  },
+  "npmName": "reveal.js",
+  "npmFileMap": [
+    {
+      "basePath": "",
+      "files": [
+        "css/**/*.css",
+        "js/*.js",
+        "lib/**/*.js",
+        "lib/**/*.css",
+        "lib/**/*.eot",
+        "lib/**/*.ttf",
+        "lib/**/*.woff",
+        "plugin/**/*.js",
+        "plugin/**/*.html"
+      ]
+    }
+  ],
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Library: [reveal.js](https://github.com/hakimel/reveal.js)

Reveal.js is already in CDNJS, but HTML files from plugins were not being uploaded, so this pull request adds the HTML files. This PR also switches to npm auto updating, which appears to be recommended over Git.

Related issue: https://github.com/hakimel/reveal.js/issues/1662

# Auto-update checklist
 * [x] Auto-update target/source is valid.
 * [x] Auto-update filemap is correct.