### PR TITLE
Drop dependencies from package.json, closes #10088

### DIFF
--- a/spec/tools/fixFormatSpec.js
+++ b/spec/tools/fixFormatSpec.js
@@ -99,6 +99,8 @@ describe('fixFormat - tool to fix package.json file of libraries', () => {
       this.packagesMock[0].engine = 'some engine';
       this.packagesMock[0].directories = 'some directories';
       this.packagesMock[0].repositories = 'some repositories';
+      this.packagesMock[0].dependencies = 'some dependencies';
+      this.packagesMock[0].optionalDependencies = 'some optional dependencies';
 
       fixFormatFile.__set__({
         fs: this.fsMock,
@@ -141,6 +143,8 @@ describe('fixFormat - tool to fix package.json file of libraries', () => {
       expect(result.engine).toBeUndefined();
       expect(result.directories).toBeUndefined();
       expect(result.repositories).toBeUndefined();
+      expect(result.dependencies).toBeUndefined();
+      expect(result.optionalDependencies).toBeUndefined();
     });
   });
 

--- a/test/valid-packages-test.js
+++ b/test/valid-packages-test.js
@@ -230,6 +230,8 @@ packages.map(function(pkg) {
     delete jsonFix.jest;
     delete jsonFix.scripts;
     delete jsonFix.devDependencies;
+    delete jsonFix.dependencies;
+    delete jsonFix.optionalDependencies;
     delete jsonFix.main;
     delete jsonFix.peerDependencies;
     delete jsonFix.contributors;
@@ -248,7 +250,7 @@ packages.map(function(pkg) {
     delete jsonFix.repositories;
 
     assert.ok(JSON.stringify(json) === JSON.stringify(jsonFix),
-            pkgName(pkg) + ": we don't need bin, jshintConfig, eslintConfig, styles, install, typescript, browserify, browser, jam, jest, scripts, devDependencies, main, peerDependencies, contributors, bugs, gitHEAD, issues, files, ignore, engines, engine, directories, repositories and maintainers fields in package.json");
+            pkgName(pkg) + ": we don't need bin, jshintConfig, eslintConfig, styles, install, typescript, browserify, browser, jam, jest, scripts, devDependencies, dependencies, optionalDependencies, main, peerDependencies, contributors, bugs, gitHEAD, issues, files, ignore, engines, engine, directories, repositories and maintainers fields in package.json");
   };
   packageVows[pname + ": There must be repository information when using auto-update config"] = function(pkg) {
     var json = parse(pkg, true);

--- a/tools/fixFormat.js
+++ b/tools/fixFormat.js
@@ -74,6 +74,8 @@ function fixFormat() {
     delete pkg.engine;
     delete pkg.directories;
     delete pkg.repositories;
+    delete pkg.dependencies;
+    delete pkg.optionalDependencies;
   }
 
   function deleteHomepage(pkg) {


### PR DESCRIPTION
Removes `dependencies` and `optionalDependencies` keys vi fixFormat script.
`peerDependencies` key is already being removed.

https://github.com/cdnjs/cdnjs/issues/10088