### PR TITLE
Add "only" option to npm test, closes #5032

### DIFF
--- a/test/support/libsToRun.js
+++ b/test/support/libsToRun.js
@@ -1,0 +1,24 @@
+var colors = require("colors");
+var glob = require("glob");
+
+function libsToRun() {
+  var onlyRunLib,
+      args = process.argv;
+
+  for (var i = 0; i < args.length; i++) {
+    if (args[i].slice(0, 6) === '--only') {
+      onlyRunLib = args[i].slice(7);
+
+      if (glob.sync(`./ajax/libs/${onlyRunLib}/`).length === 0) {
+        warningMessage = "Couldn't find lib " + onlyRunLib;
+        console.log(warningMessage.red);
+      }
+
+      break;
+    }
+  }
+
+  return onlyRunLib || '*';
+}
+
+module.exports = libsToRun;

--- a/test/valid-packages-test.js
+++ b/test/valid-packages-test.js
@@ -7,6 +7,7 @@ var vows = require("vows-si");
 var jsv = require("JSV").JSV.createEnvironment();
 var gitUrlParse = require("git-url-parse");
 var isThere = require("is-there");
+var libsToRun = require("./support/libsToRun")
 
 function parse(jsonFile, ignoreMissing) {
   var content;
@@ -37,7 +38,7 @@ function prettyError(err) {
 }
 
 // load up those files
-var packages = glob.sync("./ajax/libs/*/").map(function(pkg) {
+var packages = glob.sync(`./ajax/libs/${libsToRun()}/`).map(function(pkg) {
   if (!fs.lstatSync(pkg.substring(0, pkg.length - 1)).isSymbolicLink()) {
     return pkg + "package.json";
   }


### PR DESCRIPTION
Adds support to running tests on individual lib.

Usage:
`npm test -- --only=jquery`

If passed a lib that doesn't exist:
```
➜  ✗ npm test -- --only=cat-the-great

> vows "--only=cat-the-great"
Couldn't find lib cat-the-great
```

To run tests against the entire directory, can still use `npm test`