### PR TITLE
Transfer tween.js to git auto-update

### DIFF
--- a/ajax/libs/tween.js/package.json
+++ b/ajax/libs/tween.js/package.json
@@ -13,13 +13,16 @@
     "interpolation"
   ],
   "author": "tween.js contributors (https://github.com/tweenjs/tween.js/graphs/contributors)",
-  "npmName": "tween.js",
-  "npmFileMap": [
-    {
-      "basePath": "src",
-      "files": [
-        "Tween*"
-      ]
-    }
-  ]
+  "autoupdate": {
+    "source": "git",
+    "target": "git://github.com/tweenjs/tween.js.git",
+    "fileMap": [
+      {
+        "basePath": "src",
+        "files": [
+          "Tween*"
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
Pull request for issue: #10123
Transfer tween.js to git auto-update because release on GitHub is faster than NPM, , close #10123 
@x09326 Please help me review this pull request, thank you.
