### PR TITLE
Reorder git repo popularity detail in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,8 +12,8 @@ Note that if you are using a distribution purpose repository/package, please als
  * NPM package url (optional):
  * License and its reference:
  * GitHub / Bitbucket popularity (required):
-   - Count of stars:
    - Count of watchers:
+   - Count of stars:
    - Count of forks:
  * NPM download stats (optional):
    - Downloads in the last day:


### PR DESCRIPTION
To make the popularity order consistent with the GitHub repository page.
