### PR TITLE
Added iGrowl w/ git auto-update #10205

### DIFF
--- a/ajax/libs/iGrowl/package.json
+++ b/ajax/libs/iGrowl/package.json
@@ -1,0 +1,30 @@
+{
+	"name": "iGrowl",
+	"description": "A lightweight jQuery plugin that generates growl-like notifications with an emphasis on icons.",
+	"homepage": "https://catc.github.io/iGrowl/",
+	"author": {
+		"name": "Catalin Covic",
+		"email": "catalin.covic@gmail.com",
+		"url": "https://devpost.com/catcc"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/catc/iGrowl"
+	},
+	"keywords": [
+		"iGrowl",
+		"notifications",
+		"alerts"
+	],
+	"license": "MIT",
+	"autoupdate": {
+		"source": "git",
+		"target": "git://github.com/catc/iGrowl.git",
+		"fileMap": [{
+			"basePath": "dist",
+			"files": [
+				"**/*"
+			]
+		}]
+	}
+}


### PR DESCRIPTION
Pull request for issue: #10205
Related issue(s): # #

Checklist for **Pull request** or **lib adding request issue** follows the conventions.

Note that if you are using a distribution purpose repository/package, please also provide the url and other related info like popularity of the source code repo/package.

# Profile of the lib
 * Git repository (required):
 * Official website (optional, not the repository):
 * NPM package url (optional):
 * License and its reference:
 * GitHub / Bitbucket popularity (required):
   - Count of watchers:
   - Count of stars:
   - Count of forks:
 * NPM download stats (optional):
   - Downloads in the last day:
   - Downloads in the last week:
   - Downloads in the last month:

# Essential checklist
 * [ ] I'm the author of this library
   * [x] I would like to add link to the page of this library on CDNJS on website / readme
 * [x] This lib was not found on cdnjs repo
 * [ ] No already exist / duplicated issue and PR
 * [ ] The lib has notable popularity
   * [x] More than 100 [Stars / Watchers / Forks] on [GitHub / Bitbucket]
   * [ ] More than 500 downloads stats per month on npm registry
 * [ ] Project has public repository on famous online hosting platform (or been hosted on npm)

# Auto-update checklist
 * [ ] Has valid tags for each versions (for git auto-update)
 * [x] Auto-update setup
 * [x] Auto-update target/source is valid.
 * [ ] Auto-update filemap is correct.

# Git commit checklist
 * [x] The first line of commit message is less then 50 chars, be clean and clear, easy to understand.
 * [ ] The parent of the commit(s) in the PR is not old than 3 days.
 * [ ] Pull request is sending from a non-master branch with meaningful name.
 * [ ] Separate unrelated changes into different commits.
 * [ ] Use rebase to squash/fixup dummy/unnecessary commits into only one commit.
 * [ ] Close corresponding issue in commit message
 * [ ] Mention related issue(s), people in commit message, comment.