### PR TITLE
Update Vega auto-update config for v3

### DIFF
--- a/ajax/libs/vega/package.json
+++ b/ajax/libs/vega/package.json
@@ -13,8 +13,13 @@
     {
       "basePath": "",
       "files": [
-        "vega.js",
-        "vega.min.js"
+        "vega*.+(js|js.map)"
+      ]
+    },
+    {
+      "basePath": "build",
+      "files": [
+        "vega*.+(js|js.map)"
       ]
     }
   ],


### PR DESCRIPTION
Starting with Vega 3, compiled files are in `/build/`. We are already releasing beta builds. With this change, they will be available on cdnjs.