### PR TITLE
[author] Connect openlayers to npm

### DIFF
--- a/ajax/libs/openlayers/package.json
+++ b/ajax/libs/openlayers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openlayers",
-  "filename": "ol.js",
-  "version": "3.20.1",
+  "filename": "OpenLayers.js",
+  "version": "2.13.1",
   "description": "OpenLayers is a JavaScript library for building map applications on the web.",
   "homepage": "http://openlayers.org/",
   "license": "BSD-2-Clause",

--- a/ajax/libs/openlayers/package.json
+++ b/ajax/libs/openlayers/package.json
@@ -1,14 +1,24 @@
 {
   "name": "openlayers",
-  "filename": "OpenLayers.js",
-  "version": "2.13.1",
+  "filename": "ol.js",
+  "version": "3.20.1",
   "description": "OpenLayers is a JavaScript library for building map applications on the web.",
   "homepage": "http://openlayers.org/",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "keywords": [
     "map",
     "openlayers",
+    "ol",
     "maps"
+  ],
+  "npmName": "openlayers",
+  "npmFileMap": [
+    {
+      "basePath": "dist",
+      "files": [
+        "**/*"
+      ]
+    }
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
Related issue: #69

OpenLayers is on npm, and version 4.0.0 is about to be released. There is also `ol3` here, but that implies version 3.x, which will be a bit weird to go on when major releases are >3.