### PR TITLE
npm test will error when filename is a directory, closes #10073

### DIFF
--- a/test/valid-packages-test.js
+++ b/test/valid-packages-test.js
@@ -99,14 +99,14 @@ packages.map(function(pkg) {
                 .join("\n"));
     }
   };
-  packageVows[pname + ": filename from package.json exists"] = function(pkg) {
+  packageVows[pname + ": filename from package.json exists and is a file (not a directory)"] = function(pkg) {
     var json = parse(pkg, true);
     if (json.version === undefined) {
       return;
     }
     var filePath = "./ajax/libs/" + json.name + "/" + json.version +
       "/" + json.filename;
-    assert.ok(isThere(filePath),
+    assert.ok(isThere.file(filePath),
                   filePath + " does not exist but is referenced in package.json!");
   };
   packageVows[pname + ": name in package.json should be parent folder name"] = function(pkg) {


### PR DESCRIPTION
Pull request for issue: #10073 

Uses addition of `file` method to is-there module, which allows to check if the path exists _and_ is a file (not a directory).

`npm test` will fail if filename points to a directory.