### PR TITLE
Add git auto-update config of bootstrap-rtl

### DIFF
--- a/ajax/libs/bootstrap-rtl/package.json
+++ b/ajax/libs/bootstrap-rtl/package.json
@@ -19,5 +19,17 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/morteza/bootstrap-rtl.git"
+  },
+  "autoupdate": {
+    "source": "git",
+    "target": "git://github.com/morteza/bootstrap-rtl.git",
+    "fileMap": [
+      {
+        "basePath": "dist",
+        "files": [
+          "css/**/*"
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
Pull request for issue: #10389, #10793, #7927, #5295.

Add auto-update config in package.json of bootstrap-rtl to add its latest files to cdnjs and to add missing version of it.

Use `dist` as basePath instead of `dist/css` cause it meets the current file structure on cdnjs.

git repo: https://github.com/morteza/bootstrap-rtl

@cdnjs/intern3 Please help me review this pull request, thank you.