### PR TITLE
Transfer justgage to git auto-update

### DIFF
--- a/ajax/libs/justgage/package.json
+++ b/ajax/libs/justgage/package.json
@@ -28,13 +28,16 @@
   },
   "license": "MIT",
   "homepage": "http://justgage.com/",
-  "npmName": "justgage",
-  "npmFileMap": [
-    {
-      "basePath": "",
-      "files": [
-        "justgage*"
-      ]
-    }
-  ]
+  "autoupdate": {
+    "source": "git",
+    "target": "git://github.com/toorshia/justgage.git",
+    "fileMap": [
+      {
+        "basePath": "",
+        "files": [
+          "justgage*"
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
Pull request for issue: #10974 
-  Transfer justgage to git auto-update because there are more and newer releases on GitHub than NPM

@cdnjs/intern2 @maruilian11 Please help me review this PR, thank you.


# Profile of the lib
 * Git repository (required): https://github.com/toorshia/justgage
 * Official website (optional, not the repository): https://justgage.com/
 * NPM package url (optional): https://www.npmjs.com/package/justgage
 * License and its reference: MIT https://github.com/toorshia/justgage/blob/master/LICENSE
