### PR TITLE
Update auto-update config of vanilla-lazyload

### DIFF
--- a/ajax/libs/vanilla-lazyload/package.json
+++ b/ajax/libs/vanilla-lazyload/package.json
@@ -29,12 +29,6 @@
         "files": [
           "**/*"
         ]
-      },
-      {
-        "basePath": "src",
-        "files": [
-          "lazyload*"
-        ]
       }
     ]
   }


### PR DESCRIPTION
Pull request for issue: #11057 

- Update auto-update config of vanilla-lazyload due to author said we don't need files under `src` folder anymore. ref: https://github.com/cdnjs/cdnjs/issues/11057#issuecomment-294142091

@cdnjs/intern2 @maruilian11 Please help me review this PR, thank you.

# Profile of the lib
 * Git repository (required): https://github.com/verlok/lazyload
 * Official website (optional, not the repository): https://verlok.github.io/lazyload
 * NPM package url (optional): https://www.npmjs.com/package/vanilla-lazyload
 * License and its reference: MIT, https://github.com/verlok/lazyload/blob/master/license.md