### PR TITLE
Add license of jquery.sparkline, cc #5500

### DIFF
--- a/ajax/libs/jquery/package.json
+++ b/ajax/libs/jquery/package.json
@@ -26,7 +26,7 @@
     "type": "git",
     "url": "https://github.com/jquery/jquery.git"
   },
-  "license": "MIT",
+  "license": "BSD-3-Clause",
   "author": {
     "name": "jQuery Foundation and other contributors",
     "url": "https://github.com/jquery/jquery/blob/master/AUTHORS.txt"


### PR DESCRIPTION
ref: https://github.com/gwatts/jquery.sparkline/blob/master/src/header.js#L16
http://omnipotent.net/jquery.sparkline/#s-about , the link of "New BSD License"
