### PR TITLE
Update license(s) of fixFormat to adapt license name

### DIFF
--- a/test/valid-packages-test.js
+++ b/test/valid-packages-test.js
@@ -9,6 +9,7 @@ var gitUrlParse = require('git-url-parse');
 var isThere = require('is-there');
 var libsToRun = require('./support/libsToRun');
 var recognizedFields = require('./recognizedFields.js');
+var licenseList = JSON.parse(fs.readFileSync('tools/license-list.json', 'utf8'));
 
 function parse(jsonFile, ignoreMissing) {
   var content;
@@ -232,9 +233,20 @@ packages.map(function (pkg) {
                 pkgName(pkg) + ": authors field in package.json should be an array to include multiple authors info, if there is only one author, you should use 'author' instead, you can use our tool: tools/fixFormat.js to fix it for you.");
     }
 
+    if (content.license !== undefined) {
+      assert.ok(!Array.isArray(content.license),
+                pkgName(pkg) + ": license field in package.json should be a object or string to show its license info, if there is multiple licenses, you should use 'licenses' instead, you can use our tool: tools/fixFormat.js to fix it for you.");
+      assert.ok(licenseList.indexOf(content.license) !== -1,
+                pkgName(pkg) + ": license field in package.json should be as the same with the tools/license-list.json, you can use our tool: tools/fixFormat.js to fix it for you.");
+    }
+
     if (content.licenses !== undefined) {
       assert.ok(Array.isArray(content.licenses),
                 pkgName(pkg) + ": licenses field in package.json should be an array to include multiple licenses info, if there is only one license, you should use 'license' instead, you can use our tool: tools/fixFormat.js to fix it for you.");
+      for (var license in content.licenses) {
+          assert.ok(licenseList.indexOf(content.licenses[license]) !== -1,
+                    pkgName(pkg) + ": licenses field in package.json should be as the same with tools/license-list.json, you can use our tool: tools/fixFormat.js to fix it for you.");
+      }
     }
   };
 

--- a/tools/fixFormat.js
+++ b/tools/fixFormat.js
@@ -91,23 +91,38 @@ function fixFormat() {
       delete pkg.licenses;
     }
 
+    var licenseCheck;
     if (pkg.license !== undefined) {
       if (pkg.license.type !== undefined) {
-        if (licenses.indexOf(pkg.license.type) !== -1) {
-          pkg.license = pkg.license.type;
-        } else if (adapt(pkg.license.type)) {
-          pkg.license = adapt(pkg.license.type);
-        } else {
+        licenseCheck = adaptLicenseName(pkg.name, pkg.license.type);
+        if (licenseCheck == null) {
           unRecognizedLicense(pkg.name, pkg.license.type);
+        } else {
+          pkg.license = licenseCheck;
+        }
+      } else {
+        licenseCheck = adaptLicenseName(pkg.name, pkg.license);
+        if (licenseCheck == null) {
+          unRecognizedLicense(pkg.name, pkg.license);
+        } else {
+          pkg.license = licenseCheck;
         }
       }
     } else if (pkg.licenses !== undefined) {
       for (license in pkg.licenses) {
         if (pkg.licenses[license].type !== undefined) {
-          if (licenses.indexOf(pkg.licenses[license].type) !== -1) {
-            pkg.licenses[license] = pkg.licenses[license].type;
-          } else {
+          licenseCheck = adaptLicenseName(pkg.name, pkg.licenses[license].type);
+          if (licenseCheck == null) {
             unRecognizedLicense(pkg.name, pkg.licenses[license].type);
+          } else {
+            pkg.licenses[license] = licenseCheck;
+          }
+        } else {
+          licenseCheck = adaptLicenseName(pkg.name, pkg.licenses[license]);
+          if (licenseCheck == null) {
+            unRecognizedLicense(pkg.name, pkg.licenses[license]);
+          } else {
+            pkg.licenses[license] = licenseCheck;
           }
         }
       }
@@ -177,6 +192,16 @@ function fixFormat() {
       case 'Apache License 2.0':
         return 'Apache-2.0';
         break;
+    }
+  }
+
+  function adaptLicenseName(pkgName, licenseName) {
+    if (licenses.indexOf(licenseName) !== -1) {
+      return licenseName;
+    } else if (adapt(licenseName)) {
+      return adapt(licenseName);
+    } else {
+      return;
     }
   }
 


### PR DESCRIPTION
Update the `tools/fixFormat.js` to fix format about `licenses` which can't adapt the license name.

It can't work when I run the `tools/fixFormat.js` to fix format about `licenses`, as the followings:
```
  "licenses": [
    "MIT",
    "GPLv2"
  ],
```
The result is same with the above.


I update the `tools/fixFormat.js` to fix format about `licenses` and let it can adapt the license name, as the followings:
```
  "licenses": [
    "MIT",
    "GPL-2.0"
  ],
```
