### PR TITLE
Update typed.js autoupdate config

### DIFF
--- a/ajax/libs/typed.js/package.json
+++ b/ajax/libs/typed.js/package.json
@@ -17,7 +17,7 @@
     "target": "git://github.com/mattboldt/typed.js.git",
     "fileMap": [
       {
-        "basePath": "dist",
+        "basePath": "lib",
         "files": [
           "**/*"
         ]


### PR DESCRIPTION
The base path has changed from `dist` to `lib` since v2.0
