### PR TITLE
Update .gitignore for all inferno dummy versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ node_modules/
 /ajax/libs/esri-leaflet-geocoder/2.2.5
 /ajax/libs/vega-tooltip/0.3.1
 /ajax/libs/jqBootstrapValidation/2.0.0-alpha
-/ajax/libs/inferno/1.*.*-alpha.*
+/ajax/libs/inferno/*-alpha.*
 /ajax/libs/crypto-js/release-3.1.2*
 /ajax/libs/trackpad-scroll-emulator/version_1.0
 /ajax/libs/date-fns/v.*


### PR DESCRIPTION
Pull request for issue: #10840
Related issue(s): https://github.com/cdnjs/cdnjs/pull/11561#issuecomment-319275422
Update .gitignore line 21 from `/ajax/libs/inferno/1.*.*-alpha.*` to `/ajax/libs/inferno/*-alpha.*` to exclude all possible inferno dummy versions in the future.