### PR TITLE
Fix auto-update.js to drop empty files from npm auto-update

### DIFF
--- a/auto-update.js
+++ b/auto-update.js
@@ -191,9 +191,12 @@ var processNewVersion = function (pkg, version) {
 
         var copyPart = path.relative(libContentsPath, extractFilePath);
         var copyPath = path.join(libPath, copyPart);
-        fs.mkdirsSync(path.dirname(copyPath));
-        fs.copySync(extractFilePath, copyPath);
-        fs.chmodSync(copyPath, '0644');
+        if (fs.statSync(extractFilePath).size !== 0){
+          // don't copy the empty file from the source
+          fs.mkdirsSync(path.dirname(copyPath));
+          fs.copySync(extractFilePath, copyPath);
+          fs.chmodSync(copyPath, '0644');
+        }
         updated = true;
       });
     });


### PR DESCRIPTION
Pull request for issue: #11049 

By checking if size of each file from the source equals zero, which means it is a empty file. We take the file only if it is not empty.