### PR TITLE
update the license of jquery-form-validator

### DIFF
--- a/ajax/libs/jquery-form-validator/package.json
+++ b/ajax/libs/jquery-form-validator/package.json
@@ -33,8 +33,6 @@
       }
     ]
   },
-  "license": {
-    "type": "Dual licensed under the MIT or GPL Version 2 licenses",
-    "url": "http://www.gnu.org/licenses/gpl-2.0.html"
-  }
+  "license":"MIT",
+
 }


### PR DESCRIPTION
update it because the license  jquery-form-validator used changed, cc #11931 
