### PR TITLE
Update ionicons license info in package.json

### DIFF
--- a/ajax/libs/ionicons/package.json
+++ b/ajax/libs/ionicons/package.json
@@ -22,9 +22,7 @@
       }
     ]
   },
-  "license": {
-    "name": "MIT"
-  },
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/driftyco/ionicons.git"


### PR DESCRIPTION
Update it because it didn't contain `url` field, cc #11931.
Ref: https://github.com/ionic-team/ionicons/blob/master/LICENSE