### PR TITLE
Update ionic license info in package.json

### DIFF
--- a/ajax/libs/ionic/package.json
+++ b/ajax/libs/ionic/package.json
@@ -21,9 +21,7 @@
       }
     ]
   },
-  "license": {
-    "name": "MIT"
-  },
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/driftyco/ionic.git"


### PR DESCRIPTION
Update it because the license format is wrong, cc #11931
Ref: https://github.com/ionic-team/ionic/blob/master/LICENSE#L4