### PR TITLE
Update yepnope license info in package.json

### DIFF
--- a/ajax/libs/yepnope/package.json
+++ b/ajax/libs/yepnope/package.json
@@ -12,9 +12,6 @@
     "type": "git",
     "url": "https://github.com/SlexAxton/yepnope.js"
   },
-  "license": {
-    "type": "New BSD",
-    "url": "https://github.com/SlexAxton/yepnope.js/blob/master/LICENSE.md"
-  },
+  "license": "BSD-3-Clause",
   "author": "Alex Sexton, Ralph Holzmann"
 }


### PR DESCRIPTION
Update it because the license yepnope used changed, cc #11931 
SPDX short identifier: BSD-3-Clause
Ref: https://github.com/SlexAxton/yepnope.js/blob/master/LICENSE.md


