### PR TITLE
Add roundabout license info in package.json

### DIFF
--- a/ajax/libs/roundabout/package.json
+++ b/ajax/libs/roundabout/package.json
@@ -19,5 +19,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/fredleblanc/roundabout.git"
-  }
+  },
+  "license": "BSD-3-Clause"
 }


### PR DESCRIPTION
cc #11931
Update it because the license roundabout used changed
Ref: https://github.com/fredleblanc/roundabout/blob/master/jquery.roundabout.js#L11-L40
