### PR TITLE
Update jshashes license info in package.json

### DIFF
--- a/ajax/libs/jshashes/package.json
+++ b/ajax/libs/jshashes/package.json
@@ -7,10 +7,7 @@
     "url": "https://github.com/h2non/jshashes"
   },
   "author": "Tomas Aparicio <tomas@aparicio.me>",
-  "license": {
-    "type": "New BSD",
-    "url": "http://github.com/h2non/jshashes/raw/master/LICENSE"
-  },
+  "license": "BSD-3-Clause",
   "filename": "hashes.min.js",
   "keywords": [
     "hash",


### PR DESCRIPTION
Update it because the license format is wrong, cc #11931
Ref: https://github.com/h2non/jshashes/blob/master/LICENSE