### PR TITLE
Update jo license info in package.json

### DIFF
--- a/ajax/libs/jo/package.json
+++ b/ajax/libs/jo/package.json
@@ -12,8 +12,5 @@
     "type": "git",
     "url": "https://github.com/davebalmer/jo.git"
   },
-  "license": {
-    "type": "Redistribution",
-    "url": "http://joapp.com/docs/#License"
-  }
+  "license": "BSD-2-Clause"
 }


### PR DESCRIPTION
Update it because the license format is wrong, cc #11931
Ref: https://github.com/davebalmer/jo/blob/ec767af487b8653778c36168c7b3a5f478753cc5/LICENSE.mdown