### PR TITLE
Update legojs license info in package.json

### DIFF
--- a/ajax/libs/legojs/package.json
+++ b/ajax/libs/legojs/package.json
@@ -4,6 +4,7 @@
   "filename": "lego.min.js",
   "version": "0.0.1",
   "npmName": "legojs",
+  "license": "MIT",
   "npmFileMap": [
     {
       "basePath": "",


### PR DESCRIPTION
Update it because the license format is wrong, cc #11931
Ref: https://github.com/tybenz/presentation-js-legos/blob/gh-pages/js/reveal.js#L4