### PR TITLE
Update jquery.form license info

### DIFF
--- a/ajax/libs/jquery.form/package.json
+++ b/ajax/libs/jquery.form/package.json
@@ -22,7 +22,7 @@
   "author": "Kevin Morris",
   "licenses": [
     "MIT",
-    "LGPL-3.0"
+    "LGPL-2.1"
   ],
   "autoupdate": {
     "source": "git",


### PR DESCRIPTION
Update it because the license jquery.form used changed, cc #11931
Ref: https://github.com/jquery-form/form#license