### PR TITLE
 Update jquery-mockjax license info in package.json 

### DIFF
--- a/ajax/libs/jquery-mockjax/package.json
+++ b/ajax/libs/jquery-mockjax/package.json
@@ -11,13 +11,7 @@
   ],
   "author": "Jonathan Sharp (http://jdsharp.com/)",
   "homepage": "http://code.appendto.com/plugins/jquery-mockjax/",
-  "licenses": [
-    "MIT",
-    {
-      "type": "GPLv2",
-      "url": "http://appendto.com/open-source-licenses"
-    }
-  ],
+  "licenses": [ "MIT", "GPL-2.0" ],
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/jakerella/jquery-mockjax.git",

--- a/ajax/libs/jquery-mockjax/package.json
+++ b/ajax/libs/jquery-mockjax/package.json
@@ -11,7 +11,10 @@
   ],
   "author": "Jonathan Sharp (http://jdsharp.com/)",
   "homepage": "http://code.appendto.com/plugins/jquery-mockjax/",
-  "licenses": [ "MIT", "GPL-2.0" ],
+  "licenses": [
+    "MIT",
+    "GPL-2.0"
+  ],
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/jakerella/jquery-mockjax.git",


### PR DESCRIPTION
Update it because the license jquery-mockjax's SPDX short identifier is "GPL-2.0", cc #11931
Ref: http://appendto.com/open-source-licenses