### PR TITLE
Update jquery.pep license identify format to SPDX package.json

### DIFF
--- a/ajax/libs/jquery.pep/package.json
+++ b/ajax/libs/jquery.pep/package.json
@@ -10,10 +10,7 @@
     "pep"
   ],
   "homepage": "http://pep.briangonzalez.org",
-  "license": {
-    "name": "MIT",
-    "url": "http://opensource.org/licenses/MIT"
-  },
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/briangonzalez/jquery.pep.js"


### PR DESCRIPTION
Update it because it license is "MIT"
