### PR TITLE
Update jquery.tablesorter license in package.json

### DIFF
--- a/ajax/libs/jquery.tablesorter/package.json
+++ b/ajax/libs/jquery.tablesorter/package.json
@@ -19,7 +19,7 @@
   ],
   "licenses": [
     "MIT",
-    "deprecated_GPL-2.0+"
+    "GPL-2.0"
   ],
   "homepage": "http://mottie.github.com/tablesorter/",
   "repository": {


### PR DESCRIPTION
Update it because it's license is "MIT"