### PR TITLE
Update Vague.js license info in package.json

### DIFF
--- a/ajax/libs/Vague.js/package.json
+++ b/ajax/libs/Vague.js/package.json
@@ -26,4 +26,5 @@
     "type": "git",
     "url": "git://github.com/GianlucaGuarini/Vague.js.git"
   }
+  "license": "MIT";
 }


### PR DESCRIPTION
Update it because its license is "MIT"