### PR TITLE
Update Snowstorm license info in package.json

### DIFF
--- a/ajax/libs/Snowstorm/package.json
+++ b/ajax/libs/Snowstorm/package.json
@@ -8,10 +8,7 @@
     "xmas"
   ],
   "homepage": "http://www.schillmania.com/projects/snowstorm/",
-  "license": {
-    "name": "BSD License",
-    "url": "https://github.com/scottschiller/Snowstorm/blob/master/license.txt"
-  },
+  "license": "BSD-3-Clause",
   "repository": {
     "type": "git",
     "url": "https://github.com/scottschiller/snowstorm/"


### PR DESCRIPTION
Update it because its license is "BSD"