### PR TITLE
Update moment-range repo location

### DIFF
--- a/ajax/libs/moment-range/package.json
+++ b/ajax/libs/moment-range/package.json
@@ -20,7 +20,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/gf3/moment-range.git"
+    "url": "https://github.com/rotaready/moment-range.git"
   },
   "license": "UNLICENSE",
   "author": "Gianni Chiappetta <gianni@runlevel6.org> (http://butt.zone)"


### PR DESCRIPTION
Pull request for issue: N/A
Related issue(s): N/A

CDN already hosts `moment-range` (https://cdnjs.com/libraries/moment-range).
The repo has since changed location - updating accordingly.

Old location: https://github.com/gf3/moment-range
New location: https://github.com/rotaready/moment-range

Auto-update is currently working (cdnjs correctly detected 3.1.0 release).

# Profile of the lib
 * Git repository (required): https://github.com/rotaready/moment-range
 * NPM package url (optional): https://www.npmjs.com/package/moment-range
 * License and its reference: Unlicense
 * GitHub popularity (required):
   - Count of watchers: 39
   - Count of stars: 998
   - Count of forks: 157
 * NPM download stats (optional):
   - Downloads in the last day: 8,532
   - Downloads in the last week: 53,048
   - Downloads in the last month: 200,476

I am a maintainer of the library.