### PR TITLE
Update popmotion auto-update config

### DIFF
--- a/ajax/libs/popmotion/package.json
+++ b/ajax/libs/popmotion/package.json
@@ -30,16 +30,13 @@
     "svg"
   ],
   "license": "MIT",
-  "autoupdate": {
-    "source": "git",
-    "target": "git://github.com/Popmotion/popmotion.git",
-    "fileMap": [
-      {
-        "basePath": "",
-        "files": [
-          "popmotion*.js"
-        ]
-      }
-    ]
-  }
+  "npmName": "popmotion",
+  "npmFileMap": [
+    {
+      "basePath": "dist",
+      "files": [
+        "popmotion*.js"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
The latest version on CDNJS is [4.3.4](https://cdnjs.com/libraries/popmotion).
The latest version on the github repo is now [8.1.1](https://github.com/Popmotion/popmotion/tree/master/packages/popmotion/dist).
The basepath has been changed from `""` to `"packages/popmotion/dist"`.

Pull request for issue: #12324 
