### PR TITLE
Update auto-update config of store.js

### DIFF
--- a/ajax/libs/store.js/package.json
+++ b/ajax/libs/store.js/package.json
@@ -16,11 +16,9 @@
     "target": "git://github.com/marcuswestin/store.js.git",
     "fileMap": [
       {
-        "basePath": "",
+        "basePath": "dist",
         "files": [
-          "store.js",
-          "store.min.js",
-          "store+json2.min.js"
+          "**/*"
         ]
       }
     ]


### PR DESCRIPTION
Related issue: #12336
The current version on CDNJS is outdated because the file structure on the upstream repo changed. I made this change so that auto-update can successfully grab the latest version.