### PR TITLE
Update jquery.activity-indicator lib license property in package.json

### DIFF
--- a/ajax/libs/jquery.activity-indicator/package.json
+++ b/ajax/libs/jquery.activity-indicator/package.json
@@ -12,5 +12,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/neteye/jquery-plugins"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
cc #5500
According to:
https://github.com/cdnjs/cdnjs/blob/master/ajax/libs/jquery.activity-indicator/1.0.0/jquery.activity-indicator.js#L5


Pull request for issue: #
Related issue(s): # #

Checklist for **Pull request** or **lib adding request issue** follows the conventions.

Note that if you are using a distribution purpose repository/package, please also provide the url and other related info like popularity of the source code repo/package.

# Profile of the lib
 * Git repository (required): disappear
 * Official website (optional, not the repository): disappear
 * License and its reference: MIT

# Git commit checklist
 * [x] The first line of commit message is less then 50 chars; clean, clear and easy to understand.
 * [x] The parent of the commit(s) in the PR is not older than 3 days.
 * [x] Pull request is sent from a non-master branch with a meaningful name.
 * [x] Separate unrelated changes into different commits.
 * [x] Use rebase to squash/fixup dummy/unnecessary commits into only one commit.
 * [x] Close corresponding issue in commit message
 * [x] Mention related issue(s), people in commit message, comment.
