### PR TITLE
Update jquery-validation-unobtrusive npmFileMap in package.json

### DIFF
--- a/ajax/libs/jquery-validation-unobtrusive/package.json
+++ b/ajax/libs/jquery-validation-unobtrusive/package.json
@@ -19,9 +19,9 @@
   "npmName": "jquery-validation-unobtrusive",
   "npmFileMap": [
     {
-      "basePath": "",
+      "basePath": "dist",
       "files": [
-        "jquery.validate.unobtrusive*"
+        "**/*"
       ]
     }
   ]


### PR DESCRIPTION
Update the npmFileMap to correctly point to the dist directory

Pull request for issue: https://github.com/cdnjs/cdnjs/issues/12647
Related issue(s): https://github.com/cdnjs/cdnjs/issues/7176


