### PR TITLE
Update zrender auto-update config, add `dist` folder

### DIFF
--- a/ajax/libs/zrender/package.json
+++ b/ajax/libs/zrender/package.json
@@ -38,6 +38,12 @@
         "files": [
           "zrender*"
         ]
+      },
+      {
+        "basePath": "dist",
+        "files": [
+          "**/*"
+        ]
       }
     ]
   }


### PR DESCRIPTION
Before version `3.6.1`, the built artifacts of [zrender](
https://www.npmjs.com/package/zrender) were placed in [`build/`](https://github.com/ecomfe/zrender/tree/master/build). After that version, built files were placed in [`dist/`](https://github.com/ecomfe/zrender/tree/master/dist). As a result, cdnjs was unable to find updates and it's currently [11 versions behind](https://cdnjs.com/libraries/zrender).

The current version is [`4.0.4`](https://github.com/ecomfe/zrender/releases).

This PR adds the missing `dist` folder to the `package.json` so that the auto updater can locate the artifacts in the updated path.
