### PR TITLE
Update .gitignore for v-mask incompatible versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -256,7 +256,7 @@ node_modules/
 /ajax/libs/numbered/1.0.0
 /ajax/libs/jquery-bracket/release-*
 /ajax/libs/jquery.ime/1.0.0+20131229
-/ajax/libs/v-mask/v1.3.0
+/ajax/libs/v-mask/v1.[0-2].*
 
 #ignore snapshot tags
 /ajax/libs/*/*snapshot*


### PR DESCRIPTION
Prevent v1.0.0 ~ v1.2.0 from being fetched via .gitignore


Pull request for issue: #https://github.com/cdnjs/cdnjs/pull/10446#issuecomment-393571819
Related issue: #10446 

# Git commit checklist
 * [x] The first line of commit message is less then 50 chars; clean, clear and easy to understand.
 * [x] The parent of the commit(s) in the PR is not older than 3 days.
 * [x] Pull request is sent from a non-master branch with a meaningful name.
 * [x] Separate unrelated changes into different commits.
 * [x] Use rebase to squash/fixup dummy/unnecessary commits into only one commit.
 * [x] Close corresponding issue in commit message
 * [x] Mention related issue(s), people in commit message, comment.
