### PR TITLE
[New] Update qunit auto-update and homepage

### DIFF
--- a/ajax/libs/qunit/package.json
+++ b/ajax/libs/qunit/package.json
@@ -3,7 +3,7 @@
   "filename": "qunit.min.js",
   "version": "2.4.1",
   "description": "An easy-to-use JavaScript Unit Testing framework.",
-  "homepage": "http://qunitjs.com/",
+  "homepage": "https://qunitjs.com/",
   "keywords": [
     "framework",
     "toolkit",

--- a/ajax/libs/qunit/package.json
+++ b/ajax/libs/qunit/package.json
@@ -19,7 +19,7 @@
     "name": "jQuery Foundation and other contributors",
     "url": "https://github.com/jquery/qunit/blob/master/AUTHORS.txt"
   },
-  "npmName": "qunitjs",
+  "npmName": "qunit",
   "npmFileMap": [
     {
       "basePath": "qunit",


### PR DESCRIPTION
The npm name was update due to it was changed from qunitjs to qunit
According to: https://github.com/cdnjs/cdnjs/blob/master/ajax/libs/qunit/package.json#L22
close #12849


Pull request for issue: #12849
# Git commit checklist
 * [x] The first line of commit message is less then 50 chars; clean, clear and easy to understand.
 * [x] The parent of the commit(s) in the PR is not older than 3 days.
 * [x] Pull request is sent from a non-master branch with a meaningful name.
 * [x] Separate unrelated changes into different commits.
 * [x] Use rebase to squash/fixup dummy/unnecessary commits into only one commit.
 * [x] Close corresponding issue in commit message
 * [x] Mention related issue(s), people in commit message, comment.
