### PR TITLE
[author] Update SCION package information

### DIFF
--- a/ajax/libs/scion/package.json
+++ b/ajax/libs/scion/package.json
@@ -12,10 +12,10 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jbeard4/SCION.git"
+    "url": "https://gitlab.com/scion-scxml/scion.git"
   },
   "filename": "scxml.min.js",
-  "npmName": "scxml",
+  "npmName": "scion",
   "npmFileMap": [
     {
       "basePath": "dist",


### PR DESCRIPTION
SCION has moved to gitlab. This pull request updates the `repository.url` and `npmFile` fields in package.json.

This fixes issue #12971 (I think).

The original pull requests to add SCION to cdnjs are here:
* #212
* #8782

Thank you for your help with this.