### PR TITLE
update hls.js to use npm instead of git

### DIFF
--- a/ajax/libs/hls.js/package.json
+++ b/ajax/libs/hls.js/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "hls.js",
   "npmName": "hls.js",
   "npmFileMap": [
     {

--- a/ajax/libs/hls.js/package.json
+++ b/ajax/libs/hls.js/package.json
@@ -1,21 +1,17 @@
 {
-  "name": "hls.js",
+  "npmName": "hls.js",
+  "npmFileMap": [
+    {
+      "basePath": "dist",
+      "files": [
+        "**/!(*-demo.*)"
+      ]
+    }
+  ],
   "version": "0.10.1",
   "filename": "hls.min.js",
   "description": "JavaScript HLS client using MediaSourceExtension",
   "license": "Apache-2.0",
-  "autoupdate": {
-    "source": "git",
-    "target": "git://github.com/video-dev/hls.js.git",
-    "fileMap": [
-      {
-        "basePath": "dist",
-        "files": [
-          "**/!(*-demo.*)"
-        ]
-      }
-    ]
-  },
   "repository": {
     "type": "git",
     "url": "git://github.com/video-dev/hls.js"


### PR DESCRIPTION
the dist folder only exists in the npm package, not the github repo

Related issue(s): https://github.com/video-dev/hls.js/issues/1890 + https://github.com/cdnjs/cdnjs/issues/12927

This was also suggested by @sashberd [here](https://github.com/cdnjs/cdnjs/issues/12927#issuecomment-436564536).

>On npm there are a lot of version with canary in name. Do we need to host them?
Usually we do not host such versions, thus you need to add second commit and add all versions with canary to cdnjs .gitigonre file.

We publish every commit to master as a new canary package. It would be great if you could also host these versions, but if not it's fine to exclude these.

Thanks!