### PR TITLE
Update tesseract.js auto-update config to use npm instead of git

### DIFF
--- a/ajax/libs/tesseract.js/package.json
+++ b/ajax/libs/tesseract.js/package.json
@@ -16,16 +16,13 @@
     "url": "https://github.com/naptha/tesseract.js.git"
   },
   "homepage": "http://tesseract.projectnaptha.com/",
-  "autoupdate": {
-    "source": "git",
-    "target": "git://github.com/naptha/tesseract.js.git",
-    "fileMap": [
-      {
-        "basePath": "dist",
-        "files": [
-          "**/!(*.md)"
-        ]
-      }
-    ]
-  }
+  "npmName": "tesseract.js",
+  "npmFileMap": [
+    {
+      "basePath": "dist",
+      "files": [
+        "**/!(*.md)"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Related issue(s): #9279 #9717

As tesseract.js releasve 1.0.11 and 1.0.12 on 2019/11/15, it is expected that cdnjs will auto-update the new versions. But until today no update triggered.

To solve the issue, I think it is better we switch to npm autoupdate mechanism, please kindly help to merge this PR to make it work.

Thanks 😃 