### PR TITLE
[author] Update jsonld auto-update config and author url

### DIFF
--- a/ajax/libs/jsonld/package.json
+++ b/ajax/libs/jsonld/package.json
@@ -6,7 +6,7 @@
   "author": {
     "name": "Digital Bazaar, Inc.",
     "email": "support@digitalbazaar.com",
-    "url": "http://digitalbazaar.com/"
+    "url": "https://digitalbazaar.com/"
   },
   "repository": {
     "type": "git",
@@ -23,9 +23,11 @@
   "npmName": "jsonld",
   "npmFileMap": [
     {
-      "basePath": "js",
+      "basePath": "dist",
       "files": [
-        "jsonld.js"
+        "jsonld.js",
+        "jsonld.min.js",
+        "jsonld.min.js.map"
       ]
     }
   ],


### PR DESCRIPTION
I'm a jsonld.js upstream maintainer.  Many jsonld.js versions ago the npm package file layout for browsers changed to move from using the raw source js to using built js files in the dist dir.  This update reflects those changes for the latest release.

Related issue(s): https://github.com/digitalbazaar/jsonld.js/issues/278