### PR TITLE
Update git url for SortableJS

### DIFF
--- a/ajax/libs/Sortable/package.json
+++ b/ajax/libs/Sortable/package.json
@@ -1,7 +1,6 @@
 {
   "name": "Sortable",
   "title": "Sortable",
-  "version": "1.7.0",
   "filename": "Sortable.min.js",
   "homepage": "http://rubaxa.github.io/Sortable/",
   "description": "Minimalist JavaScript library for reorderable drag-and-drop lists on modern browsers and touch devices. No jQuery. Supports AngularJS and any CSS library, e.g. Bootstrap.",

--- a/ajax/libs/Sortable/package.json
+++ b/ajax/libs/Sortable/package.json
@@ -1,6 +1,7 @@
 {
   "name": "Sortable",
   "title": "Sortable",
+  "version": "1.6.0",
   "filename": "Sortable.min.js",
   "homepage": "http://rubaxa.github.io/Sortable/",
   "description": "Minimalist JavaScript library for reorderable drag-and-drop lists on modern browsers and touch devices. No jQuery. Supports AngularJS and any CSS library, e.g. Bootstrap.",

--- a/ajax/libs/Sortable/package.json
+++ b/ajax/libs/Sortable/package.json
@@ -1,13 +1,13 @@
 {
   "name": "Sortable",
   "title": "Sortable",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "filename": "Sortable.min.js",
   "homepage": "http://rubaxa.github.io/Sortable/",
   "description": "Minimalist JavaScript library for reorderable drag-and-drop lists on modern browsers and touch devices. No jQuery. Supports AngularJS and any CSS library, e.g. Bootstrap.",
   "repository": {
     "type": "git",
-    "url": "git://github.com/rubaxa/Sortable.git"
+    "url": "git://github.com/SortableJS/Sortable.git"
   },
   "keywords": [
     "sortable",
@@ -18,7 +18,7 @@
   "license": "MIT",
   "autoupdate": {
     "source": "git",
-    "target": "git://github.com/rubaxa/Sortable.git",
+    "target": "git://github.com/SortableJS/Sortable.git",
     "fileMap": [
       {
         "basePath": "",


### PR DESCRIPTION
It seems the github repo for this library was moved out of the original developer's github account to its own project account.
- Old repo: https://github.com/RubaXa/Sortable
- New repo: https://github.com/SortableJS/Sortable
Also seems the latest version is v1.7.0.