### PR TITLE
Fix repo URL issues with animateplus

### DIFF
--- a/ajax/libs/animateplus/package.json
+++ b/ajax/libs/animateplus/package.json
@@ -5,7 +5,7 @@
   "filename": "animateplus.min.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/bendc/animateplus.git"
+    "url": "https://github.com/bendc/animateplus.git"
   },
   "keywords": [
     "animate",


### PR DESCRIPTION
As reported in #13182 there was an issue with the repository URL for this lib. Upon investigation, it had an unwanted `git+` prefix on the URL which was the cause of the issues. This PR fixes that issue.