### PR TITLE
Remove not found homepage URL for animations

### DIFF
--- a/ajax/libs/animations/package.json
+++ b/ajax/libs/animations/package.json
@@ -3,7 +3,6 @@
   "filename": "js/animations.min.js",
   "version": "2.1",
   "description": "A versatile CSS3 animation pack with various usages, trigger CSS3 animations as elements enter the viewport, as you hover with a mouse or by binding them via JavaScript functions.",
-  "homepage": "http://www.cloud-eight.com/github/animations/",
   "keywords": [
     "css3",
     "animation"


### PR DESCRIPTION
As reported in #13182 the URL that animations linked to for the homepage was no longer working and so should be removed. This PR removes the dead URL.