### PR TITLE
Add Community Discord to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![devDependency Status](https://img.shields.io/david/dev/cdnjs/cdnjs.svg)](https://david-dm.org/cdnjs/cdnjs#info=devDependencies)
 [![tip for next commit](https://img.shields.io/badge/tip4commit-info-orange.svg)](https://tip4commit.com/github/cdnjs/cdnjs)
 [![Bountysource](https://www.bountysource.com/badge/team?team_id=11914&style=bounties_posted)](https://www.bountysource.com/teams/cdnjs/bounties?utm_source=cdnjs&utm_medium=shield&utm_campaign=bounties_posted)
+[![Community Discord](https://img.shields.io/discord/502173972264255488.svg?colorB=7289DA&label=community%20Discord&style=flat)](https://discord.gg/38ZpCFP)
 
 [![Throughput Graph](https://graphs.waffle.io/cdnjs/cdnjs/throughput.svg)](https://waffle.io/cdnjs/cdnjs/metrics/throughput)
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ To contribute to CDNJS, please refer to [CONTRIBUTING.md](https://github.com/cdn
 
 **Working on your first Pull Request?** Learn how from this *free* series: [How to Contribute to an Open Source Project on GitHub](https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github)
 
+Want to chat with other users of the CDNJS service and some of the team before making your contribution? You can join our [community Discord](https://discord.gg/38ZpCFP) where you can post questions and chat with everyone.
+
 ## API usage
 
 See the [API page](https://cdnjs.com/api) on our website or read: [documents/api.md](https://github.com/cdnjs/cdnjs/blob/master/documents/api.md)


### PR DESCRIPTION
A small PR to add the Discord community to the readme file.
We've been given some cool perks by Discord now (custom invite: https://discord.gg/cdnjs and custom splash art on that page).
They asked if we could link the Discord from this repo as well as the site :)