### PR TITLE
Update chartjs-plugin-zoom auto-update config to use npm instead of git

### DIFF
--- a/ajax/libs/chartjs-plugin-zoom/package.json
+++ b/ajax/libs/chartjs-plugin-zoom/package.json
@@ -16,16 +16,13 @@
     "type": "git",
     "url": "https://github.com/chartjs/chartjs-plugin-zoom.git"
   },
-  "autoupdate": {
-    "source": "git",
-    "target": "git://github.com/chartjs/chartjs-plugin-zoom.git",
-    "fileMap": [
-      {
-        "basePath": "",
-        "files": [
-          "+(chartjs-plugin-zoom|Chart.Zoom)*.+(css|js|map)"
-        ]
-      }
-    ]
-  }
+  "npmName": "chartjs-plugin-zoom",
+  "npmFileMap": [
+    {
+      "basePath": "dist",
+      "files": [
+        "**/*"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Related PR in chartjs-plugin-zoom: https://github.com/chartjs/chartjs-plugin-zoom/pull/202

Hi,

We're working on auto-deployment of npm releases of `chartjs-plugin-zoom`. In this context, we switch to npm autoupdate mechanism.

Thanks!