### PR TITLE
[Update] webui-popover

### DIFF
--- a/ajax/libs/webui-popover/package.json
+++ b/ajax/libs/webui-popover/package.json
@@ -1,5 +1,5 @@
 {
-  "filename": "jquery.webui-popover.min.js",
+  "filename": "dist/jquery.webui-popover.min.js",
   "name": "webui-popover",
   "description": "A enhancement popover plugin for Bootstrap ,but you can use it stand-alone without Bootstrap!",
   "author": "Sandy Duan <sanddywalker@gmail.com>",
@@ -22,7 +22,7 @@
         "basePath": "",
         "files": [
           "dist/*",
-          "img/*
+          "img/*"
         ]
       }
     ]

--- a/ajax/libs/webui-popover/package.json
+++ b/ajax/libs/webui-popover/package.json
@@ -19,9 +19,10 @@
     "target": "git://github.com/sandywalker/webui-popover.git",
     "fileMap": [
       {
-        "basePath": "dist",
+        "basePath": "",
         "files": [
-          "**/*"
+          "dist/*",
+          "img/*
         ]
       }
     ]


### PR DESCRIPTION
Fix to an existing library.

The library makes reference to the img folder from assets inside the dist folder so it will be best for us to include both the dist & img folders.