### PR TITLE
Add FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+open_collective: cdnjs
+custom: https://www.bountysource.com/teams/cdnjs


### PR DESCRIPTION
Add Sponsor button at the top of the repository by adding FUNDING.yml

The custom field can be set a single sponsorship URL, so I pick https://www.bountysource.com/teams/cdnjs as the custom sponsorship URL.
The open_collective field can direct to https://opencollective.com/cdnjs.

Ref:
- https://github.blog/2019-05-23-announcing-github-sponsors-a-new-way-to-contribute-to-open-source/
- https://help.github.com/en/articles/displaying-a-sponsor-button-in-your-repository#about-funding-files

Thank you.

## Git commit checklist

* [x] The first line of commit message is less then 50 chars; clean, clear and easy to understand.
* [x] The parent of the commit(s) in the PR is not older than 3 days.
* [x] Pull request is sent from a non-master branch with a meaningful name.
* [x] Separate unrelated changes into different commits.
* [x] Use rebase to squash/fixup dummy/unnecessary commits into only one commit.
* [x] Close corresponding issue in commit message
* [x] Mention related issue(s), people in commit message, comment.
