### PR TITLE
Switches raty package to npm update

### DIFF
--- a/ajax/libs/raty/package.json
+++ b/ajax/libs/raty/package.json
@@ -23,17 +23,14 @@
     "url": "https://github.com/wbotelhos/raty"
   },
   "version": "2.8.0",
-  "autoupdate": {
-    "source": "git",
-    "target": "git://github.com/wbotelhos/raty.git",
-    "fileMap": [
-      {
-        "basePath": "lib",
-        "files": [
-          "**/?(jquery.)raty*",
+  "npmName": "raty-js",
+  "npmFileMap": [
+    {
+      "basePath": "lib",
+      "files": [
+          "**/?(jquery.)raty*", 
           "images/*.png"
         ]
-      }
-    ]
-  }
+    }
+  ]
 }


### PR DESCRIPTION
git auto update is enabled for this package (raty) but it looks like author released a new version on the npm but it doesn't tagged it on GitHub and because of that CDNJS does not include the new version 2.9.0

According to your docs `npm` is the preferred way to update packages, so I thought this PR would work in both ways.

https://github.com/cdnjs/cdnjs/blob/3df219e22a51443dfa76c9ea535b672df36f1f2b/ajax/libs/raty/package.json#L25-L38

Related Links:

https://www.npmjs.com/package/raty-js
https://github.com/wbotelhos/raty
