### PR TITLE
Update Mithril's package info

### DIFF
--- a/ajax/libs/mithril/package.json
+++ b/ajax/libs/mithril/package.json
@@ -3,8 +3,8 @@
   "npmName": "mithril",
   "version": "2.0.3",
   "filename": "mithril.min.js",
-  "description": "Mithril.js beta build - use this to help us test the releases before they are released",
-  "homepage": "http://lhorie.github.io/mithril",
+  "description": "A framework for building brilliant applications",
+  "homepage": "http://mithril.js.org",
   "license": "MIT",
   "keywords": [
     "mvc",
@@ -13,7 +13,7 @@
   "author": "Leo Horie <leohorie@hotmail.com> (http://lhorie.blogspot.com/)",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lhorie/mithril.js.git"
+    "url": "https://github.com/MithrilJS/mithril.js.git"
   },
   "npmFileMap": [
     {
@@ -21,7 +21,8 @@
       "files": [
         "mithril.js",
         "mithril.min.js",
-        "mithril.min.js.map"
+        "mithril.min.js.map",
+        "stream/stream.js"
       ]
     }
   ]


### PR DESCRIPTION
It was severely outdated, including a dead link to the old website. I'm updating it to point to up-to-date information, with the description ripped straight from the current `package.json`.

Also, in v1, a `mithril/stream` submodule was added for a streams implementation with its own separate source file, but this was similarly erroneously *not* included.

Now if only the autoupdate mechanism also could by option copy the description and website from the published `package.json`.