### PR TITLE
Update preact auto-update to include hooks and compat modules

### DIFF
--- a/ajax/libs/preact/package.json
+++ b/ajax/libs/preact/package.json
@@ -23,6 +23,18 @@
       "files": [
         "!(*.+(flow|ts|mjs|mjs.map)|preact.esm.*)"
       ]
+    },
+    {
+      "basePath": "hooks/dist",
+      "files": [
+        "!(*.+(flow|ts|mjs|mjs.map)|hooks.esm.*)"
+      ]
+    },
+    {
+      "basePath": "compat/dist",
+      "files": [
+        "!(*.+(flow|ts|mjs|mjs.map)|compat.esm.*)"
+      ]
     }
   ],
   "license": "MIT"


### PR DESCRIPTION
# Update to existing library - preact

Pull request for issue: #13485

My only inquiry for this change is:

Does the auto update script handle the older versions (8.5.2) gracefully if the `hooks` and `compat` folders don't exist?

## Profile of the lib

* Git repository (required): https://github.com/preactjs/preact
* NPM package url (optional): https://www.npmjs.com/package/preact
* License and its reference: https://github.com/preactjs/preact/blob/master/LICENSE
* GitHub / Bitbucket popularity (required):
  * Count of watchers: 439
  * Count of stars: 23,753
  * Count of forks: 1,248
* NPM download stats (optional):
  * Downloads in the last week: 196,625

## Essential checklist

* [ ] I'm the author of this library
  * [ ] I would like to add link to the page of this library on CDNJS on website / readme
* [x] This lib was not found on cdnjs repo (`hooks` and `compat` modules in preact lib)
* [x] Doesn't already exist / has duplicate issue and PR
* [x] The lib has notable popularity
  * [x] More than 200 [Stars / Watchers / Forks] on [GitHub / Bitbucket]
  * [x] More than 800 downloads stats per month on npm registry
* [x] Project has public repository on famous online hosting platform (or been hosted on npm)

## Auto-update checklist

* [x] Has valid tags for each versions (for git auto-update)
* [x] Auto-update setup
* [x] Auto-update target/source is valid.
* [x] Auto-update filemap is correct.

## Git commit checklist

* [x] The first line of commit message is less then 50 chars; clean, clear and easy to understand.
* [x] The parent of the commit(s) in the PR is not older than 3 days.
* [x] Pull request is sent from a non-master branch with a meaningful name.
* [x] Separate unrelated changes into different commits.
* [x] Use rebase to squash/fixup dummy/unnecessary commits into only one commit.
* [x] Close corresponding issue in commit message
* [x] Mention related issue(s), people in commit message, comment.
