### PR TITLE
Update mixitup license info in package.json

### DIFF
--- a/ajax/libs/mixitup/package.json
+++ b/ajax/libs/mixitup/package.json
@@ -24,10 +24,13 @@
       }
     ]
   },
-  "license": {
-    "type": "Creative Commons Attribution-NoDerivs 3.0 Unported",
-    "url": "http://creativecommons.org/licenses/by-nd/3.0/"
-  },
+  "licenses": [
+    "CC-BY-ND-3.0",
+    {
+      "type": "Commercial License",
+      "url": "https://www.kunkalabs.com/mixitup/licenses/"
+    }
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/patrickkunka/mixitup"


### PR DESCRIPTION
Change license format to cdnjs convention and add commercial license. #11931
Reference: https://www.kunkalabs.com/mixitup/licenses/