### PR TITLE
Docs: Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# CDNJS - the best front-end resource CDN for free!
+<h1 align="center">
+    <a href="https://cdnjs.com"><img src="https://raw.githubusercontent.com/cdnjs/brand/master/logo/standard/dark-512.png" width="175px" alt="< cdnjs >"></a>
+</h1>
+ 
+<h3 align="center">The #1 free and open source CDN built to make life easier for developers.</h3>
+
+---
 
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/cdnjs/cdnjs/issues?utf8=%E2%9C%93&q=is%3Aopen%20is%3Aissue%20label%3AHacktoberfest%20-label%3A%22in%20progress%22%20)
 [![License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat)](https://github.com/cdnjs/cdnjs/blob/master/MIT-LICENSE)

--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@
 [![Liberapay](https://img.shields.io/badge/liberapay-donate-f6c915.svg)](https://liberapay.com/cdnjs/)
 [![tip4commit](https://img.shields.io/badge/tip4commit-info-orange.svg)](https://tip4commit.com/github/cdnjs/cdnjs)
 
-[![Throughput Graph](https://graphs.waffle.io/cdnjs/cdnjs/throughput.svg)](https://waffle.io/cdnjs/cdnjs/metrics/throughput)
-
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 ## Table of Contents

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 ## Table of Contents
 
 * [Introduction](#introduction)
+  * [Other Repositories](#other-repositories)
   * [Support Us](#support-us)
 * [latest version URL support](#latest-version-url-support)
 * [Contributing](#contributing)
@@ -37,11 +38,21 @@
 
 ## Introduction
 
-This is the main repository to maintain the libraries' assets on CDNJS. For our website and API, please refer to the [new-website](https://github.com/cdnjs/new-website) repository. You can find all repositories at [CDNJS](https://github.com/cdnjs/) on GitHub!
+This is the main repository for cdnjs that contains all the libraries' assets that are available through the cdnjs CDN service.
 
 CDNJS is a free and open source project to organize and provide popular front-end web development resources to developers via a fast CDN infrastructure without usage limitations and fees. We want to help individual library/framework developers distribute their projects, and web developers supercharge their websites! With our great free CDN service, developers can focus on their projects and website development. Developers no longer have to spend time worrying about how to set-up a CDN for projects or website assets. We hope to make web development easier, as well as your websites and the WWW faster and safer.
 
 Currently, CDNJS is rated No. 2 ([ref](https://w3techs.com/technologies/overview/content_delivery/all)) in web front-end CDN services and has great performance. We fully support [https](https://en.wikipedia.org/wiki/HTTPS), [SPDY](https://en.wikipedia.org/wiki/SPDY), [http/2.0](https://http2.github.io/), and [SRI](https://www.w3.org/TR/SRI/). These will **boost** and **secure** your website with zero configuration. *(Note: You'll still need to take care of server-side and application layer security issues. We make it better, but we can't help you too much if you implement a bad practice.)*
+
+### Other Repositories
+
+For our website and API, please refer to the [new-website](https://github.com/cdnjs/new-website) repository.
+
+For the full cdnjs branding and brand-related assets/guidelines, please see the [brand](https://github.com/cdnjs/brand) repository.
+
+For our monthly CDN stats and usage reports, check out the [cf-stats](https://github.com/cdnjs/cf-stats) repository.
+
+You can find all our repositories at [github.com/cdnjs](https://github.com/cdnjs/) on GitHub!
 
 ### Support Us!
 


### PR DESCRIPTION
 - Uses the cdnjs “brand header” in the readme doc
 - Removes the broken wafflebot throughout graph
 - Updates intro section with more info on our other repos