### PR TITLE
elFinder latest version 2.1.53

### DIFF
--- a/ajax/libs/elfinder/package.json
+++ b/ajax/libs/elfinder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elfinder",
-  "version": "2.1.50",
+  "version": "2.1.53",
   "filename": "js/elfinder.min.js",
   "description": "Open-source file manager for web, written in JavaScript using jQuery and jQuery UI.",
   "author": "Studio-42 (https://github.com/Studio-42/elFinder)",


### PR DESCRIPTION
The latest version of elFinder is 2.1.53. rel. #13709.