### PR TITLE
Add datatables-plugins via single package.json w/ npm auto-update

### DIFF
--- a/ajax/libs/datatables-plugins/package.json
+++ b/ajax/libs/datatables-plugins/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "datatables-plugins",
+  "description": "Various small plug-ins for DataTables including feature, ordering, search and internationalisation plug-ins.",
+  "keywords": [
+    "DataTables",
+    "jQuery",
+    "plugins"
+  ],
+  "author": "SpryMedia Ltd and contributors",
+  "license": "MIT",
+  "homepage": "https://datatables.net/plug-ins",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Plugins.git"
+  },
+  "npmName": "datatables.net-plugins",
+  "npmFileMap": [
+    {
+      "basePath": "",
+      "files": [
+        "*/**/*"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Resolves #5234
Resolves #6646

Note: *.lang is not in the cdnjs whitelist, and so will not be served currently.