### PR TITLE
Add ant-design-icons-svg via single package.json w/ npm auto-update

### DIFF
--- a/ajax/libs/ant-design-icons-svg/package.json
+++ b/ajax/libs/ant-design-icons-svg/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "ant-design-icons-svg",
+  "description": "Abstract nodes for ant design icons.",
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "homepage": "https://github.com/ant-design/ant-design-icons/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ant-design/ant-design-icons.git"
+  },
+  "npmName": "@ant-design/icons-svg",
+  "npmFileMap": [
+    {
+      "basePath": "inline-svg",
+      "files": [
+        "**/*.svg"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Resolves #9500

It seems the original antd font requested is no longer used, so I'm adding this in instead.
