### PR TITLE
Update placeholder-shiv license in package.json

### DIFF
--- a/ajax/libs/placeholder-shiv/package.json
+++ b/ajax/libs/placeholder-shiv/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/walterdavis/placeholder-shiv.git"
   },
   "license": {
-    "type": "BSD 3-Clause",
+    "type": "BSD-3-Clause",
     "url": "https://github.com/walterdavis/placeholder-shiv/blob/master/LICENSE.txt"
   }
 }

--- a/ajax/libs/placeholder-shiv/package.json
+++ b/ajax/libs/placeholder-shiv/package.json
@@ -1,7 +1,7 @@
 {
   "name": "placeholder-shiv",
   "filename": "placeholder-shiv.min.js",
-  "description": "A tiny polyfill for the placeholder attribute. Requires Prototype.js or jQuery",
+  "description": "Tiny polyfill for the placeholder form element attribute. Requires Prototype.js or jQuery.",
   "version": "0.2",
   "keywords": [
     "html5",
@@ -12,7 +12,7 @@
     "url": "https://github.com/walterdavis/placeholder-shiv.git"
   },
   "license": {
-    "type": "BSD",
+    "type": "BSD 3-Clause",
     "url": "https://github.com/walterdavis/placeholder-shiv/blob/master/LICENSE.txt"
   }
 }


### PR DESCRIPTION
Update it because the license placeholder-shiv used has been updated, cc [#11931 ](https://github.com/cdnjs/cdnjs/issues/11931)
SPDX short identifier: BSD 3-Clause
ref: https://github.com/walterdavis/placeholder-shiv/blob/master/LICENSE.txt
