### PR TITLE
Update popper.js w/ npm auto-update

### DIFF
--- a/ajax/libs/popper.js/package.json
+++ b/ajax/libs/popper.js/package.json
@@ -1,11 +1,11 @@
 {
   "name": "popper.js",
   "filename": "popper.min.js",
-  "version": "1.16.1",
+  "version": "2.3.3",
   "description": "A kickass library to manage your poppers",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/FezVrasta/popper.js.git"
+    "url": "git+https://github.com/popperjs/popper-core.git"
   },
   "keywords": [
     "tooltips",
@@ -16,7 +16,7 @@
   "author": "Federico Zivolo <federico.zivolo@gmail.com>",
   "license": "MIT",
   "homepage": "https://popper.js.org/",
-  "npmName": "popper.js",
+  "npmName": "@popperjs/core",
   "npmFileMap": [
     {
       "basePath": "dist",

--- a/ajax/libs/popper.js/package.json
+++ b/ajax/libs/popper.js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "popper.js",
-  "filename": "popper.min.js",
-  "version": "2.3.3",
+  "filename": "umd/popper.min.js",
+  "version": "1.16.1",
   "description": "A kickass library to manage your poppers",
   "repository": {
     "type": "git",


### PR DESCRIPTION
perhaps the change in package name from `popper.js` to `popper-core` demands a new folder in cdnjs, similar to the new package in npmjs.