### PR TITLE
autoupdate: switch from github to npm

### DIFF
--- a/ajax/libs/jsxgraph/package.json
+++ b/ajax/libs/jsxgraph/package.json
@@ -20,19 +20,21 @@
     "type": "git",
     "url": "https://github.com/jsxgraph/jsxgraph.git"
   },
-  "autoupdate": {
-    "source": "git",
-    "target": "git://github.com/jsxgraph/jsxgraph.git",
-    "fileMap": [
-      {
-        "basePath": "update_cdnjs",
-        "files": [
-          "*"
-        ]
-      }
-    ]
-  },
-  "namespace": "JXG",  
+  "npmName": "jsxgraph",
+  "npmFileMap": [
+    {
+      "basePath": "distrib",
+      "files": [
+        "jsxgraphcore.js",
+        "jsxgraph.css",
+        "geonext.min.js",
+        "intergeo.min.js",
+        "geogebra.min.js",
+        "sketch.min.js"
+      ]
+    }
+  ],
+  "namespace": "JXG",
   "licenses": [
     "MIT",
     "LGPL-3.0"


### PR DESCRIPTION
Since auto-update from github still does not work for JSXGraph we switch to npm.
Thanks for the good work!