### PR TITLE
Update issue template links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,9 +1,9 @@
 blank_issues_enabled: true
 contact_links:
   - name: Request a new library
-    url: https://github.com/cdnjs/packages/issues/new?template=library-request.md
+    url: https://github.com/cdnjs/packages/issues/new?assignees=&labels=%F0%9F%8F%B7+Library+Request&template=library-request.yml&title=Add%3A+xxx
     about: If you are looking to request a new library, please do so in the cdnjs/packages repository!
     
   - name: Request a library update
-    url: https://github.com/cdnjs/packages/issues/new?template=update-request.md
+    url: https://github.com/cdnjs/packages/issues/new?assignees=&labels=%F0%9F%93%A6+Update+Request&template=update-request.yml&title=Update%3A+xxx
     about: Is a library missing new versions? Please make a request for our team to update it in the cdnjs/packages repository!


### PR DESCRIPTION
We switched over to using YML issue templates in cdnjs/packages a while ago to have custom forms -- this PR updates the links when creating an issue in this repo to point the user to the new templates in cdnjs/packages.