### PR TITLE
Switch sync to using self-hosted runner

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   sync:
     concurrency: sync
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
      - name: clone


### PR DESCRIPTION
Self-hosted runner is a `s-8vcpu-16gb` DigitalOcean Droplet.
